### PR TITLE
Multi-index automigration and per-model settings

### DIFF
--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -136,18 +136,23 @@ ESConnector.prototype.removeMappings = function (modelNames, callback) {
     Promise.map(
         mappingsToRemove,
         function (mapping) {
-            return db.indices.deleteMapping({
-                index: settings.index,
-                type: mapping.name
-            })
-                .then(function (body) {
-                    log('ESConnector.prototype.removeMappings', mapping.name, body);
-                    return Promise.resolve();
-                },
-                function (err) {
-                    console.trace(err.message);
-                    return Promise.reject(err);
-                });
+            var defaults = self.addDefaults(mapping.name);
+            return db.indices.existsType(defaults).then(function(exists) {
+                if (!exists) return Promise.resolve();
+                
+                return db.indices.deleteMapping(defaults)
+                    .then(function (body) {
+                        log('ESConnector.prototype.removeMappings', mapping.name, body);
+                        return Promise.resolve();
+                    },
+                    function (err) {
+                        console.trace(err.message);
+                        return Promise.reject(err);
+                    });
+            }, function(err) {
+                console.trace(err.message);
+                return Promise.reject(err);
+            });
         },
         {concurrency: 1}
     )
@@ -179,13 +184,10 @@ ESConnector.prototype.setupMappings = function (modelNames, callback) {
     Promise.map(
         mappingsToSetUp,
         function (mapping) {
-            return db.indices.putMapping(
-                {
-                    index: settings.index,
-                    type: mapping.name,
-                    body: {properties: mapping.properties}
-                }
-            ).then(
+            var defaults = self.addDefaults(mapping.name);
+            return db.indices.putMapping(_.defaults({
+                body: {properties: mapping.properties}
+            }, defaults)).then(
                 function (body) {
                     log('ESConnector.prototype.setupMappings', mapping.name, body);
                     return Promise.resolve();
@@ -317,6 +319,11 @@ ESConnector.prototype.addDefaults = function (modelName) {
         filter.index = this.searchIndex;
     }
     filter.type = modelName;
+    
+    var modelClass = this._models[modelName];
+    if (modelClass && _.isObject(modelClass.settings.elasticsearch)) {
+        _.extend(filter, modelClass.settings.elasticsearch);
+    }
     return filter;
 };
 
@@ -746,12 +753,9 @@ ESConnector.prototype.destroyAll = function destroyAll(modelName, whereClause, c
     var body = {
         query: self.buildWhere(modelName, idName, whereClause).query
     };
-
-    self.db.deleteByQuery({
-        index: self.searchIndex,
-        type: self.modelName,
-        body: body
-    }).then(
+    
+    var defaults = self.addDefaults(modelName);
+    self.db.deleteByQuery(_.defaults({ body: body }, defaults)).then(
         function (response) {
             cb(null, response);
         },
@@ -788,20 +792,17 @@ ESConnector.prototype.destroyAll = function destroyAll(modelName, whereClause, c
  * @param {String} where criteria
  * @param {Function} done callback
  */
-ESConnector.prototype.count = function count(model, done, where) {
+ESConnector.prototype.count = function count(modelName, done, where) {
     var self = this;
-    log('ESConnector.prototype.count', 'model', model, 'where', where);
+    log('ESConnector.prototype.count', 'model', modelName, 'where', where);
 
-    var idName = self.idName(model);
+    var idName = self.idName(modelName);
     var body = {
-        query: self.buildWhere(model, idName, where).query
+        query: self.buildWhere(modelName, idName, where).query
     };
-
-    self.db.count({
-        index: self.searchIndex,
-        type: self.modelName,
-        body: body
-    }).then(
+    
+    var defaults = self.addDefaults(modelName);
+    self.db.count(_.defaults({ body: body }, defaults)).then(
         function (response) {
             done(null, response.count);
         }, function (err) {
@@ -832,21 +833,20 @@ ESConnector.prototype.count = function count(model, done, where) {
  * @param {String} id row identifier
  * @param {Function} done callback
  */
-ESConnector.prototype.find = function find(model, id, done) {
+ESConnector.prototype.find = function find(modelName, id, done) {
     var self = this;
-    log('ESConnector.prototype.find', 'model', model, 'id', id);
+    log('ESConnector.prototype.find', 'model', modelName, 'id', id);
 
     if (id===undefined || id===null) {
         throw new Error('id not set!');
     }
-
-    self.db.get({
-        index: self.searchIndex,
-        type: model,
+    
+    var defaults = self.addDefaults(modelName);
+    self.db.get(_.defaults({
         id: self.getDocumentId(id)
-    }).then(
+    }, defaults)).then(
         function (response) {
-            done(null, self.dataSourceToModel(model, response));
+            done(null, self.dataSourceToModel(modelName, response));
         }, function (err) {
             console.trace(err.message);
             if (err) {
@@ -862,13 +862,13 @@ ESConnector.prototype.find = function find(model, id, done) {
  * @param {String} id row identifier
  * @param {Function} done callback
  */
-ESConnector.prototype.destroy = function destroy(model, id, done) {
+ESConnector.prototype.destroy = function destroy(modelName, id, done) {
     var self = this;
     if (self.debug) {
-        log('destroy', 'model', model, 'id', id);
+        log('destroy', 'model', modelName, 'id', id);
     }
 
-    var filter = self.addDefaults(model);
+    var filter = self.addDefaults(modelName);
     filter[self.idField] = self.getDocumentId(id);
     if (!filter[self.idField]) {
         throw new Error('Document id not setted!');
@@ -900,16 +900,15 @@ ESConnector.prototype.updateAttributes = function updateAttrs(modelName, id, dat
     if (id===undefined || id===null) {
         throw new Error('id not set!');
     }
-
-    self.db.update({
-        index: self.searchIndex,
-        type: modelName,
+    
+    var defaults = self.addDefaults(modelName);
+    self.db.update(_.defaults({
         id: id,
         body: {
             doc : data,
             'doc_as_upsert': false
         }
-    }).then(
+    }, defaults)).then(
         function (response) {
             console.log('response:',response);
             // TODO: what does the framework want us to return as arguments w/ callback?
@@ -931,19 +930,18 @@ ESConnector.prototype.updateAttributes = function updateAttrs(modelName, id, dat
  * @param {String} id row identifier
  * @param {function} done callback
  */
-ESConnector.prototype.exists = function (model, id, done) {
+ESConnector.prototype.exists = function (modelName, id, done) {
     var self = this;
-    log('ESConnector.prototype.exists', 'model', model, 'id', id);
+    log('ESConnector.prototype.exists', 'model', modelName, 'id', id);
 
     if (id===undefined || id===null) {
         throw new Error('id not set!');
     }
-
-    self.db.exists({
-        index: self.searchIndex,
-        type: model,
+    
+    var defaults = self.addDefaults(modelName);
+    self.db.exists(_.defaults({
         id: self.getDocumentId(id)
-    }).then(
+    }, defaults)).then(
         function (exists) {
             done(null, exists);
         }, function (err) {
@@ -1025,16 +1023,15 @@ ESConnector.prototype.updateOrCreate = function updateOrCreate(modelName, data, 
     if (id===undefined || id===null) {
         throw new Error('id not set!');
     }
-
-    self.db.update({
-        index: self.searchIndex,
-        type: modelName,
+    
+    var defaults = self.addDefaults(modelName);
+    self.db.update(_.defaults({
         id: id,
         body: {
             doc : data,
             'doc_as_upsert': true
         }
-    }).then(
+    }, defaults)).then(
         function (response) {
             /**
              * In the case of an update, elasticsearch only provides a confirmation that it worked
@@ -1103,19 +1100,58 @@ ESConnector.prototype.automigrate = function (models, cb) {
         log('ESConnector.prototype.automigrate', 'models', models);
 
         models = models || Object.keys(self._models);
+        
+        var indices = [];
 
         _.forEach(models, function (model){
             log('ESConnector.prototype.automigrate', 'model', model);
+            var defaults = self.addDefaults(model);
+            indices.push(defaults.index);
         });
+        
+        indices = _.uniq(indices);
+        
         if(self.settings.mappings) {
-            self.removeMappings(models,function(err){
-                if (err) {
+            Promise.map(
+                indices,
+                function (indexName) {
+                    var params = { index: indexName };
+                    
+                    var createIndex = function() {
+                        return self.db.indices.create(params).then(function(info) {
+                            return Promise.resolve();
+                        }, function(err) {
+                            console.trace(err.message);
+                            return Promise.reject(err);
+                        });
+                    };
+                    
+                    return self.db.indices.delete(params).then(function(info) {
+                        return createIndex();
+                    }, function(err) {
+                        console.trace(err.message);
+                        if (err.message.indexOf('IndexMissingException') > -1) {
+                            return createIndex();
+                        }
+                        return Promise.reject(err);
+                    });
+                },
+                {concurrency: 1}
+            )
+                .then(function () {
+                    self.removeMappings(models, function(err){
+                        if (err) {
+                            cb(err);
+                        }
+                        else {
+                            self.setupMappings(models, cb);
+                        }
+                    });
+                })
+                .catch(function(err){
+                    log('ESConnector.prototype.automigrate', 'failed');
                     cb(err);
-                }
-                else {
-                    self.setupMappings(models, cb);
-                }
-            });
+                });
         }
         else {
             cb();

--- a/test/02.basic-querying.test.js
+++ b/test/02.basic-querying.test.js
@@ -30,6 +30,10 @@ describe('basic-querying', function () {
             role: {type: String, index: true},
             order: {type: Number, index: true, sort: true},
             vip: {type: Boolean}
+        }, {
+            elasticsearch: {
+                type: 'Customer' // could set override here
+            }
         });
 
         setTimeout(function(){


### PR DESCRIPTION
Automigrate now correctly recreates an index (delete, create, set mapping) - fixes #20
Additionally, Model.settings.elasticsearch can be used to set defaults (index, type).

@pulkitsinghal 