### PR TITLE
support for ES compatible DSL in .count

### DIFF
--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -835,7 +835,7 @@ ESConnector.prototype.count = function count(modelName, done, where) {
     log('ESConnector.prototype.count', 'model', modelName, 'where', where);
 
     var idName = self.idName(modelName);
-    var body = {
+    var body = where.native ? where.native : {
         query: self.buildWhere(modelName, idName, where).query
     };
 


### PR DESCRIPTION
add support for ES compatible DSL in .count through 'where.native' key