### PR TITLE
add support for replaceById operation

### DIFF
--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -979,7 +979,37 @@ ESConnector.prototype.updateAttributes = updateAttrs;
  * @param data
  * @param callback - should pass the following arguments to the callback:
  */
-ESConnector.prototype.replaceById = updateAttrs;
+/**
+ * Replace attributes for a model instance and persist it into the data source.
+ * @param modelName
+ * @param data
+ * @param callback - should pass the following arguments to the callback:
+ */
+function replaceById(modelName, id, data, options, callback) {
+  var self = this;
+    log('ESConnector.prototype.replaceById', 'modelName', modelName, 'id', id, 'data', data);
+
+    if (id===undefined || id===null) {
+        throw new Error('id not set!');
+    }
+
+    var defaults = self.addDefaults(modelName);
+    self.db.index(_.defaults({
+        id: id,
+        body: data,
+    }, defaults)).then(
+        function (response) {
+            callback(null, response);
+        }, function (err) {
+            console.trace(err.message);
+            if (err) {
+                return callback(err, null);
+            }
+        }
+    );
+}
+
+ESConnector.prototype.replaceById = replaceById;
 
 /**
  * Check existence of a model instance by id

--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -939,7 +939,8 @@ ESConnector.prototype.destroy = function destroy(modelName, id, done) {
  * NOTES:
  * > The _source field need to be enabled for this feature to work.
  */
-ESConnector.prototype.updateAttributes = function updateAttrs(modelName, id, data, callback) {
+
+function updateAttrs(modelName, id, data, options, callback) {
     var self = this;
     log('ESConnector.prototype.updateAttributes', 'modelName', modelName, 'id', id, 'data', data);
 
@@ -956,7 +957,7 @@ ESConnector.prototype.updateAttributes = function updateAttrs(modelName, id, dat
         }
     }, defaults)).then(
         function (response) {
-            //console.log('response:',response);
+            // console.log('response:',response);
             // TODO: what does the framework want us to return as arguments w/ callback?
             callback(null, response);
             //callback(null, response._id);
@@ -969,6 +970,16 @@ ESConnector.prototype.updateAttributes = function updateAttrs(modelName, id, dat
         }
     );
 };
+
+ESConnector.prototype.updateAttributes = updateAttrs;
+
+/**
+ * Replace attributes for a model instance and persist it into the data source.
+ * @param modelName
+ * @param data
+ * @param callback - should pass the following arguments to the callback:
+ */
+ESConnector.prototype.replaceById = updateAttrs;
 
 /**
  * Check existence of a model instance by id


### PR DESCRIPTION
This fixes the exeption when running: `POST /Model/{id}/replace`

`Error: The connector elasticsearch does not support replaceById
operation. This is not a bug in LoopBack. Please contact the
authors of the connector, preferably via GitHub issues.`

closes #48
