### PR TITLE
Only provide indexName in exists-method

### DIFF
--- a/lib/setupIndex.js
+++ b/lib/setupIndex.js
@@ -35,7 +35,7 @@ var setupIndex = function setupIndex (indexName) {
     index: indexName,
     body: self.searchIndexSettings
   };
-  return self.db.indices.exists(params)
+  return self.db.indices.exists({index: indexName})
       .then(function(exists) {
         log('ESConnector.prototype.setupIndices', 'self.db.indices.exists()', 'response:', exists);
         if (!exists) {


### PR DESCRIPTION
... so that the HEAD-request generated by the elasticSearch-client doesn't have a body.
The body causes a 403-forbidden response on amazon AWS ElasticSearch service