### PR TITLE
Include filter issue fixed

### DIFF
--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -740,7 +740,11 @@ ESConnector.prototype.all = function all(model, filter, done) {
                     });
                 }
                 log('ESConnector.prototype.all', 'model', model, 'result', JSON.stringify(result,null,2));
-                done(null, result);
+				if (filter && filter.include) {
+					self._models[model].model.include(result, filter.include, done);
+				} else {
+					done(null, result);
+				}
             }, function (err) {
                 console.trace(err.message);
                 if (err) {
@@ -759,7 +763,11 @@ ESConnector.prototype.all = function all(model, filter, done) {
                     result.push(self.dataSourceToModel(model, item, idName));
                 });
                 log('ESConnector.prototype.all', 'model', model, 'result', JSON.stringify(result,null,2));
-                done(null, result);
+				if (filter && filter.include) {
+					self._models[model].model.include(result, filter.include, done);
+				} else {
+					done(null, result);
+				}
             }, function (err) {
                 console.trace(err.message);
                 if (err) {


### PR DESCRIPTION
Include filter was not working. There was a discussion about implementation of include filter in issue #28 which is still pending. I have implemented the minimum workflow to make include filter work until we optimize it for better performance.

Right now the filter works with loopback internal include method implementation and the connector just passes right arguments to loopback method to make it work. 