### PR TITLE
AWS IAM user policy rejects 'HEAD' type requests that are sent with c…

### DIFF
--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -43,7 +43,9 @@ var ESConnector = function (settings, dataSource) {
     Connector.call(this, 'elasticsearch', settings);
 
     this.searchIndex = settings.index || '';
-    this.searchIndexSettings = settings.settings || {};
+    if (settings.settings) {
+        this.searchIndexSettings = settings.settings;
+    }
     this.searchType = settings.type || '';
     this.defaultSize = (settings.defaultSize || 10);
     this.idField = 'id';
@@ -67,7 +69,7 @@ util.inherits(ESConnector, Connector);
 ESConnector.prototype.getClientConfig = function () {
     // http://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html
     var config = {
-        hosts: this.settings.hosts || {host:'127.0.0.1',port:9200},
+        hosts: this.settings.hosts || { host: '127.0.0.1', port: 9200 },
         requestTimeout: this.settings.requestTimeout,
         apiVersion: this.settings.apiVersion,
         log: this.settings.log || 'error',
@@ -125,21 +127,21 @@ ESConnector.prototype.connect = function (callback) {
         }
 
         // NOTE: any & all indices and mappings will be created or their existence verified before proceeding
-        if(self.settings.mappings) {
-          self.setupMappings()
-              .then(function(){
-                log('ESConnector.prototype.connect', 'setupMappings', 'finished');
-                callback && callback(null, self.db);
-              })
-              .catch(function(err){
-                log('ESConnector.prototype.connect', 'setupMappings', 'failed', err);
-                callback && callback(err);
-              });
+        if (self.settings.mappings) {
+            self.setupMappings()
+                .then(function () {
+                    log('ESConnector.prototype.connect', 'setupMappings', 'finished');
+                    callback && callback(null, self.db);
+                })
+                .catch(function (err) {
+                    log('ESConnector.prototype.connect', 'setupMappings', 'failed', err);
+                    callback && callback(err);
+                });
         }
         else {
-          process.nextTick(function () {
-            callback && callback(null, self.db);
-          });
+            process.nextTick(function () {
+                callback && callback(null, self.db);
+            });
         }
     }
 };
@@ -160,7 +162,7 @@ ESConnector.prototype.removeMappings = function (modelNames, callback) {
     }
     log('ESConnector.prototype.removeMappings', 'modelNames', modelNames);
 
-    var mappingsToRemove = _.filter(settings.mappings, function(mapping){
+    var mappingsToRemove = _.filter(settings.mappings, function (mapping) {
         return !modelNames || _.includes(modelNames, mapping.name);
     });
     log('ESConnector.prototype.removeMappings', 'mappingsToRemove', _.pluck(mappingsToRemove, 'name'));
@@ -170,7 +172,7 @@ ESConnector.prototype.removeMappings = function (modelNames, callback) {
         function (mapping) {
             var defaults = self.addDefaults(mapping.name);
             log('ESConnector.prototype.removeMappings', 'calling self.db.indices.existsType()');
-            return db.indices.existsType(defaults).then(function(exists) {
+            return db.indices.existsType(defaults).then(function (exists) {
                 if (!exists) return Promise.resolve();
                 log('ESConnector.prototype.removeMappings', 'calling self.db.indices.deleteMapping()');
                 return db.indices.deleteMapping(defaults)
@@ -182,38 +184,38 @@ ESConnector.prototype.removeMappings = function (modelNames, callback) {
                         console.trace(err.message);
                         return Promise.reject(err);
                     });
-            }, function(err) {
+            }, function (err) {
                 console.trace(err.message);
                 return Promise.reject(err);
             });
         },
-        {concurrency: 1}
+        { concurrency: 1 }
     )
         .then(function () {
             log('ESConnector.prototype.removeMappings', 'finished');
             callback(null, self.db); // TODO: what does the connector framework want back as arguments here?
         })
-        .catch(function(err){
+        .catch(function (err) {
             log('ESConnector.prototype.removeMappings', 'failed');
             callback(err);
         });
 };
 
 ESConnector.prototype.setupMappings = require('./setupMappings.js')({
-  log: log
-  ,lodash: _
-  ,bluebird: Promise
+    log: log
+    , lodash: _
+    , bluebird: Promise
 });
 
 ESConnector.prototype.setupMapping = require('./setupMapping.js')({
-  log: log
-  ,lodash: _
-  ,bluebird: Promise
+    log: log
+    , lodash: _
+    , bluebird: Promise
 });
 
 ESConnector.prototype.setupIndex = require('./setupIndex.js')({
-  log: log
-  ,bluebird: Promise
+    log: log
+    , bluebird: Promise
 });
 
 
@@ -224,7 +226,7 @@ ESConnector.prototype.setupIndex = require('./setupIndex.js')({
  */
 ESConnector.prototype.ping = function (cb) {
     this.db.ping({
-        requestTimeout : 1000
+        requestTimeout: 1000
     }, function (error) {
         if (error) {
             log('Could not ping ES.');
@@ -262,7 +264,7 @@ ESConnector.prototype.getValueFromProperty = function (property, value) {
         return value.toString();
     } else if (property.type === Number) {
         return Number(value);
-    } else if (property.type === Date){
+    } else if (property.type === Date) {
         return new Date(value);
     } else {
         return value;
@@ -291,11 +293,11 @@ ESConnector.prototype.matchDataToModel = function (modelName, data, esId, idName
         for (var propertyName in properties) {
             var propertyValue = data[propertyName];
             // log('ESConnector.prototype.matchDataToModel', propertyName, propertyValue);
-            if (propertyValue!==undefined && propertyValue!==null) {
+            if (propertyValue !== undefined && propertyValue !== null) {
                 document[propertyName] = self.getValueFromProperty(properties[propertyName], propertyValue);
             }
         }
-        log('ESConnector.prototype.matchDataToModel', 'document', JSON.stringify(document,null,0));
+        log('ESConnector.prototype.matchDataToModel', 'document', JSON.stringify(document, null, 0));
         return document;
     } catch (err) {
         console.trace(err.message);
@@ -310,7 +312,7 @@ ESConnector.prototype.matchDataToModel = function (modelName, data, esId, idName
  * @returns {object} modeled document
  */
 ESConnector.prototype.dataSourceToModel = function (modelName, data, idName) {
-    log('ESConnector.prototype.dataSourceToModel', 'modelName', modelName, 'data', JSON.stringify(data,null,0));
+    log('ESConnector.prototype.dataSourceToModel', 'modelName', modelName, 'data', JSON.stringify(data, null, 0));
 
     //return data._source; // TODO: super-simplify?
     return this.matchDataToModel(modelName, data._source, data._id, idName);
@@ -329,12 +331,12 @@ ESConnector.prototype.addDefaults = function (modelName) {
     //TODO: fetch index and type from `self.settings.mappings` too
     var indexFromDatasource, typeFromDatasource;
     var mappingFromDatasource = _.find(self.settings.mappings,
-        function(mapping) {
-          return mapping.name === modelName;
+        function (mapping) {
+            return mapping.name === modelName;
         });
     if (mappingFromDatasource) {
-      indexFromDatasource = mappingFromDatasource.index;
-      typeFromDatasource = mappingFromDatasource.type;
+        indexFromDatasource = mappingFromDatasource.index;
+        typeFromDatasource = mappingFromDatasource.type;
     }
 
     var filter = {};
@@ -366,35 +368,34 @@ ESConnector.prototype.addDefaults = function (modelName) {
 ESConnector.prototype.buildFilter = function (modelName, idName, criteria, size, offset) {
     var self = this;
     log('ESConnector.prototype.buildFilter', 'model', modelName, 'idName', idName,
-        'criteria', JSON.stringify(criteria,null,0));
+        'criteria', JSON.stringify(criteria, null, 0));
 
-    if (idName===undefined || idName===null) {
+    if (idName === undefined || idName === null) {
         throw new Error('idName not set!');
     }
 
     var filter = this.addDefaults(modelName);
     filter.body = {};
 
-    if (size!==undefined && size!==null) {
+    if (size !== undefined && size !== null) {
         filter.size = size;
     }
-    if (offset!==undefined && offset!==null) {
+    if (offset !== undefined && offset !== null) {
         filter.from = offset;
     }
 
     if (criteria) {
         // `criteria` is set by app-devs, therefore, it overrides any connector level arguments
-        if (criteria.limit!==undefined && criteria.limit!==null) {
+        if (criteria.limit !== undefined && criteria.limit !== null) {
             filter.size = criteria.limit;
         }
-        if (criteria.skip!==undefined && criteria.skip!==null)
-        {
+        if (criteria.skip !== undefined && criteria.skip !== null) {
             filter.from = criteria.skip;
         }
-        else if (criteria.offset!==undefined && criteria.offset!==null) { // use offset as an alias for skip
+        else if (criteria.offset !== undefined && criteria.offset !== null) { // use offset as an alias for skip
             filter.from = criteria.offset;
         }
-        if(criteria.fields) {
+        if (criteria.fields) {
             // { fields: {propertyName: <true|false>, propertyName: <true|false>, ... } }
             //filter.body.fields = self.buildOrder(model, idName, criteria.fields);
             // TODO: make it so
@@ -414,7 +415,7 @@ ESConnector.prototype.buildFilter = function (modelName, idName, criteria, size,
             ... did someone at some point of time implement an in-memory filter for FIELDS
             in the underlying loopback-connector implementation? */
         }
-        if(criteria.order) {
+        if (criteria.order) {
             log('ESConnector.prototype.buildFilter', 'will delegate sorting to buildOrder()');
             filter.body.sort = self.buildOrder(modelName, idName, criteria.order);
         }
@@ -440,7 +441,7 @@ ESConnector.prototype.buildFilter = function (modelName, idName, criteria, size,
         else if (criteria.native) {
             filter.body = criteria.native; // assume that the developer has provided ES compatible DSL
         }
-        else if (_.keys(criteria).length===0) {
+        else if (_.keys(criteria).length === 0) {
             filter.body = {
                 'query': {
                     'match_all': {}
@@ -449,7 +450,7 @@ ESConnector.prototype.buildFilter = function (modelName, idName, criteria, size,
         }
     }
 
-    log('ESConnector.prototype.buildFilter', 'constructed', JSON.stringify(filter,null,0));
+    log('ESConnector.prototype.buildFilter', 'constructed', JSON.stringify(filter, null, 0));
     return filter;
 };
 
@@ -476,12 +477,12 @@ ESConnector.prototype.buildOrder = function (model, idName, order) {
         var m = keys[index].match(/\s+(A|DE)SC$/);
         var key = keys[index];
         key = key.replace(/\s+(A|DE)SC$/, '').trim();
-        if(key === 'id' || key === idName) {
+        if (key === 'id' || key === idName) {
             key = '_uid';
         }
         if (m && m[1] === 'DE') {
             //sort[key] = -1;
-            var temp  = {};
+            var temp = {};
             temp[key] = 'desc';
             sort.push(temp);
         } else {
@@ -495,7 +496,7 @@ ESConnector.prototype.buildOrder = function (model, idName, order) {
 
 ESConnector.prototype.buildWhere = function (model, idName, where) {
     var self = this;
-    log('ESConnector.prototype.buildWhere', 'model', model, 'idName', idName, 'where', JSON.stringify(where,null,0));
+    log('ESConnector.prototype.buildWhere', 'model', model, 'idName', idName, 'where', JSON.stringify(where, null, 0));
 
     var body = {
         query: {
@@ -509,13 +510,13 @@ ESConnector.prototype.buildWhere = function (model, idName, where) {
 
     self.buildNestedQueries(body, model, idName, where);
 
-    if(body && body.query && body.query.bool && body.query.bool.must && body.query.bool.must.length === 0) {
+    if (body && body.query && body.query.bool && body.query.bool.must && body.query.bool.must.length === 0) {
         delete body.query.bool['must']; // jshint ignore:line
     }
-    if(body && body.query && body.query.bool && body.query.bool.should && body.query.bool.should.length === 0) {
+    if (body && body.query && body.query.bool && body.query.bool.should && body.query.bool.should.length === 0) {
         delete body.query.bool['should']; // jshint ignore:line
     }
-    if(body && body.query && body.query.bool && body.query.bool.must_not && body.query.bool.must_not.length === 0) { // jshint ignore:line
+    if (body && body.query && body.query.bool && body.query.bool.must_not && body.query.bool.must_not.length === 0) { // jshint ignore:line
         delete body.query.bool['must_not']; // jshint ignore:line
     }
     return body;
@@ -524,22 +525,22 @@ ESConnector.prototype.buildWhere = function (model, idName, where) {
 ESConnector.prototype.buildNestedQueries = function (body, model, idName, where, parentOperator) {
     var self = this;
     log('ESConnector.prototype.buildNestedQueries',
-        'model',  model, 'idName', idName,
-        '\nbody', JSON.stringify(body,null,0),
-        '\nwhere',  JSON.stringify(where,null,0),
+        'model', model, 'idName', idName,
+        '\nbody', JSON.stringify(body, null, 0),
+        '\nwhere', JSON.stringify(where, null, 0),
         '\nparentOperator', parentOperator);
 
-    if (_.keys(where).length===0) {
+    if (_.keys(where).length === 0) {
         body.query = {
             'match_all': {}
         };
         log('ESConnector.prototype.buildNestedQueries',
-            '\nbody', JSON.stringify(body,null,0));
+            '\nbody', JSON.stringify(body, null, 0));
     }
     else {
-        _.forEach(where, function(value, key) {
+        _.forEach(where, function (value, key) {
             var cond = value;
-            if(key === 'id' || key === idName) {
+            if (key === 'id' || key === idName) {
                 //where.match._id = value;
                 key = '_id';
             }
@@ -552,7 +553,7 @@ ESConnector.prototype.buildNestedQueries = function (body, model, idName, where,
                     cond = cond.map(function (c) {
                         self.buildNestedQueries(body, model, idName, c, key);
                         log('ESConnector.prototype.buildNestedQueries',
-                            'mapped', 'body', JSON.stringify(body,null,0));
+                            'mapped', 'body', JSON.stringify(body, null, 0));
                     });
                 }
                 // TODO: distinguish between and/or to populate must/should
@@ -569,10 +570,10 @@ ESConnector.prototype.buildNestedQueries = function (body, model, idName, where,
                 cond = cond[spec];
             }
             log('ESConnector.prototype.buildNestedQueries',
-                'spec', spec, 'key', key, 'cond', JSON.stringify(cond,null,0), 'options', options);
+                'spec', spec, 'key', key, 'cond', JSON.stringify(cond, null, 0), 'options', options);
             if (spec) {
                 if (spec === 'gte' || spec === 'gt' || spec === 'lte' || spec === 'lt') {
-                    var rangeQuery = {range:{}};
+                    var rangeQuery = { range: {} };
                     var rangeQueryGuts = {};
                     rangeQueryGuts[spec] = cond;
                     rangeQuery.range[key] = rangeQueryGuts;
@@ -582,10 +583,10 @@ ESConnector.prototype.buildNestedQueries = function (body, model, idName, where,
                 // TODO: inq, nin - In / not in an array of values.
                 if (spec === 'inq') {
                     cond.map(function (x) {
-                        var nestedQuery = {match:{}};
+                        var nestedQuery = { match: {} };
                         nestedQuery.match[key] = x;
                         log('ESConnector.prototype.buildNestedQueries',
-                            'nestedQuery', JSON.stringify(nestedQuery,null,0));
+                            'nestedQuery', JSON.stringify(nestedQuery, null, 0));
                         body.query.bool.should.push(nestedQuery);
                     });
                 }
@@ -594,11 +595,11 @@ ESConnector.prototype.buildNestedQueries = function (body, model, idName, where,
                 // TODO: like, nlike
             }
             else {
-                var nestedQuery = {match:{}};
+                var nestedQuery = { match: {} };
                 nestedQuery.match[key] = value;
                 log('ESConnector.prototype.buildNestedQueries',
                     'parentOperator', parentOperator,
-                    'nestedQuery', JSON.stringify(nestedQuery,null,0));
+                    'nestedQuery', JSON.stringify(nestedQuery, null, 0));
                 self.mergeNestedQueryWithParentOperator(body, nestedQuery, parentOperator);
                 /*if(parentOperator === 'and'){
                     body.query.bool.must.push(nestedQuery);
@@ -618,13 +619,13 @@ ESConnector.prototype.buildNestedQueries = function (body, model, idName, where,
 };
 
 ESConnector.prototype.mergeNestedQueryWithParentOperator = function (body, nestedQuery, parentOperator) {
-    if(parentOperator === 'and'){
+    if (parentOperator === 'and') {
         body.query.bool.must.push(nestedQuery);
     }
-    else if(parentOperator === 'or'){
+    else if (parentOperator === 'or') {
         body.query.bool.should.push(nestedQuery);
     }
-    else if(parentOperator === 'nor'){
+    else if (parentOperator === 'nor') {
         body.query.bool.must_not.push(nestedQuery); // jshint ignore:line
     }
     else {
@@ -668,7 +669,7 @@ ESConnector.prototype.getDocumentId = function (id) {
  */
 
 ESConnector.prototype.getDefaultIdType = function () {
-  return String;
+    return String;
 };
 
 /**
@@ -707,7 +708,7 @@ ESConnector.prototype.create = function (model, data, done) {
                 return done(err, null);
             }
         }
-    );
+        );
 };
 
 /**
@@ -723,12 +724,12 @@ ESConnector.prototype.create = function (model, data, done) {
  */
 ESConnector.prototype.all = function all(model, filter, done) {
     var self = this;
-    log('ESConnector.prototype.all', 'model', model, 'filter', JSON.stringify(filter,null,0));
+    log('ESConnector.prototype.all', 'model', model, 'filter', JSON.stringify(filter, null, 0));
 
     var idName = self.idName(model);
     log('ESConnector.prototype.all', 'idName', idName);
 
-    if(filter && filter.suggests) { // TODO: remove HACK!!!
+    if (filter && filter.suggests) { // TODO: remove HACK!!!
         self.db.suggest(
             self.buildFilter(model, idName, filter, self.defaultSize)
         ).then(
@@ -739,7 +740,7 @@ ESConnector.prototype.all = function all(model, filter, done) {
                         result.push(self.dataSourceToModel(model, item, idName));
                     });
                 }
-                log('ESConnector.prototype.all', 'model', model, 'result', JSON.stringify(result,null,2));
+                log('ESConnector.prototype.all', 'model', model, 'result', JSON.stringify(result, null, 2));
                 done(null, result);
             }, function (err) {
                 console.trace(err.message);
@@ -747,7 +748,7 @@ ESConnector.prototype.all = function all(model, filter, done) {
                     return done(err, null);
                 }
             }
-        );
+            );
     }
     else {
         self.db.search(
@@ -758,7 +759,7 @@ ESConnector.prototype.all = function all(model, filter, done) {
                 body.hits.hits.forEach(function (item) {
                     result.push(self.dataSourceToModel(model, item, idName));
                 });
-                log('ESConnector.prototype.all', 'model', model, 'result', JSON.stringify(result,null,2));
+                log('ESConnector.prototype.all', 'model', model, 'result', JSON.stringify(result, null, 2));
                 done(null, result);
             }, function (err) {
                 console.trace(err.message);
@@ -766,7 +767,7 @@ ESConnector.prototype.all = function all(model, filter, done) {
                     return done(err, null);
                 }
             }
-        );
+            );
     }
 };
 
@@ -783,7 +784,7 @@ ESConnector.prototype.destroyAll = function destroyAll(modelName, whereClause, c
         cb = whereClause;
         whereClause = {};
     }
-    log('ESConnector.prototype.destroyAll', 'modelName', modelName, 'whereClause', JSON.stringify(whereClause,null,0));
+    log('ESConnector.prototype.destroyAll', 'modelName', modelName, 'whereClause', JSON.stringify(whereClause, null, 0));
 
     var idName = self.idName(modelName);
     var body = {
@@ -792,12 +793,12 @@ ESConnector.prototype.destroyAll = function destroyAll(modelName, whereClause, c
 
     var defaults = self.addDefaults(modelName);
     var options = _.defaults({ body: body }, defaults);
-    log('ESConnector.prototype.destroyAll', 'options:', JSON.stringify(options,null,2));
+    log('ESConnector.prototype.destroyAll', 'options:', JSON.stringify(options, null, 2));
     self.db.deleteByQuery(options)
-        .then(function(response){
+        .then(function (response) {
             cb(null, response);
         })
-        .catch(function(err) {
+        .catch(function (err) {
             console.trace(err.message);
             return cb(err, null);
         });
@@ -872,7 +873,7 @@ ESConnector.prototype.find = function find(modelName, id, done) {
     var self = this;
     log('ESConnector.prototype.find', 'model', modelName, 'id', id);
 
-    if (id===undefined || id===null) {
+    if (id === undefined || id === null) {
         throw new Error('id not set!');
     }
 
@@ -888,7 +889,7 @@ ESConnector.prototype.find = function find(modelName, id, done) {
                 return done(err, null);
             }
         }
-    );
+        );
 };
 
 /**
@@ -919,7 +920,7 @@ ESConnector.prototype.destroy = function destroy(modelName, id, done) {
                 return done(err, null);
             }
         }
-    );
+        );
 };
 
 /**
@@ -932,7 +933,7 @@ ESConnector.prototype.updateAttributes = function updateAttrs(modelName, id, dat
     var self = this;
     log('ESConnector.prototype.updateAttributes', 'modelName', modelName, 'id', id, 'data', data);
 
-    if (id===undefined || id===null) {
+    if (id === undefined || id === null) {
         throw new Error('id not set!');
     }
 
@@ -940,7 +941,7 @@ ESConnector.prototype.updateAttributes = function updateAttrs(modelName, id, dat
     self.db.update(_.defaults({
         id: id,
         body: {
-            doc : data,
+            doc: data,
             'doc_as_upsert': false
         }
     }, defaults)).then(
@@ -956,7 +957,7 @@ ESConnector.prototype.updateAttributes = function updateAttrs(modelName, id, dat
                 return callback(err, null);
             }
         }
-    );
+        );
 };
 
 /**
@@ -969,7 +970,7 @@ ESConnector.prototype.exists = function (modelName, id, done) {
     var self = this;
     log('ESConnector.prototype.exists', 'model', modelName, 'id', id);
 
-    if (id===undefined || id===null) {
+    if (id === undefined || id === null) {
         throw new Error('id not set!');
     }
 
@@ -985,7 +986,7 @@ ESConnector.prototype.exists = function (modelName, id, done) {
                 return done(err, null);
             }
         }
-    );
+        );
 };
 
 /**
@@ -1012,19 +1013,19 @@ ESConnector.prototype.save = function (model, data, done) {
         log('ESConnector.prototype.save ', 'model', model, 'data', data);
     }
 
-	var idName = self.idName(model);
+    var idName = self.idName(model);
     var defaults = self.addDefaults(model);
-	var id = self.getDocumentId(data[idName]);
+    var id = self.getDocumentId(data[idName]);
 
-	if (id === undefined || id === null) {
-		return done('Document id not setted!', null);
-	}
+    if (id === undefined || id === null) {
+        return done('Document id not setted!', null);
+    }
 
-    self.db.update( _.defaults({
+    self.db.update(_.defaults({
         id: id,
-        body : {
+        body: {
             doc: data,
-			'doc_as_upsert': false
+            'doc_as_upsert': false
         }
     }, defaults))
         .then(function (response) {
@@ -1034,7 +1035,7 @@ ESConnector.prototype.save = function (model, data, done) {
                 return done(err, null);
             }
         }
-    );
+        );
 };
 
 /**
@@ -1060,7 +1061,7 @@ ESConnector.prototype.updateOrCreate = function updateOrCreate(modelName, data, 
 
     var idName = self.idName(modelName);
     var id = self.getDocumentId(data[idName]);
-    if (id===undefined || id===null) {
+    if (id === undefined || id === null) {
         throw new Error('id not set!');
     }
 
@@ -1068,7 +1069,7 @@ ESConnector.prototype.updateOrCreate = function updateOrCreate(modelName, data, 
     self.db.update(_.defaults({
         id: id,
         body: {
-            doc : data,
+            doc: data,
             'doc_as_upsert': true
         }
     }, defaults)).then(
@@ -1100,14 +1101,14 @@ ESConnector.prototype.updateOrCreate = function updateOrCreate(modelName, data, 
                 data[idName] = response._id;
                 log('ESConnector.prototype.updateOrCreate', 'assigned ID', idName, '=', response._id);
             }
-            callback(null, data, {isNewInstance:response.created});
+            callback(null, data, { isNewInstance: response.created });
         }, function (err) {
             console.trace(err.message);
             if (err) {
                 return callback(err, null);
             }
         }
-    );
+        );
 };
 
 /**
@@ -1127,9 +1128,9 @@ ESConnector.prototype.updateOrCreate = function updateOrCreate(modelName, data, 
  * @param {Function} [cb] The callback function
  */
 ESConnector.prototype.automigrate = require('./automigrate.js')({
-  log: log
-  ,lodash: _
-  ,bluebird: Promise
+    log: log
+    , lodash: _
+    , bluebird: Promise
 });
 
 module.exports.name = ESConnector.name;


### PR DESCRIPTION
AWS IAM user policy rejects the 'HEAD' type requests that are sent with content in body. The line
`this.searchIndexSettings = settings.settings || {};`
was sending '{}' in body while putting mappings on the AWS elastic search service which is resulting in failure of putting mappings in elastic search index when you initialize the application.