### PR TITLE
Added support for multiple where clause

### DIFF
--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -596,7 +596,7 @@ ESConnector.prototype.buildDeepNestedQueries = function (root, idName, where, bo
 					rangeQueryGuts[spec] = cond;
 					rangeQuery.range[key] = rangeQueryGuts;
 					if(root){
-						path.range = rangeQuery.range;
+						path.bool.must.push(rangeQuery);
 					}
 					else {
 						path.push(rangeQuery);
@@ -615,7 +615,7 @@ ESConnector.prototype.buildDeepNestedQueries = function (root, idName, where, bo
 							lte: cond[1]
 						};
 						if(root){
-							path.range = betweenArray.range;
+							path.bool.must.push(betweenArray);
 						}
 						else {
 							path.push(betweenArray);
@@ -630,7 +630,7 @@ ESConnector.prototype.buildDeepNestedQueries = function (root, idName, where, bo
 					var inArray = {terms: {}};
 					inArray.terms[key] = cond;
 					if (root) {
-						path.terms = inArray.terms;
+						path.bool.must.push(inArray);
 					}
 					else {
 						path.push(inArray);

--- a/test/01.filters.test.js
+++ b/test/01.filters.test.js
@@ -455,11 +455,17 @@ describe('Connector', function () {
 				'_uid'
 			],
 			query: {
-				range: {
-					order: {
-						gte: 3,
-						lte: 6
-					}
+				bool: {
+					must: [
+						{
+							range: {
+								order: {
+									gte: 3,
+									lte: 6
+								}
+							}
+						}
+					]
 				}
 			}
 		});
@@ -514,6 +520,126 @@ describe('Connector', function () {
 						{
 							match: {
 								vip: true
+							}
+						}
+					]
+				}
+			}
+		});
+		expect(filterCriteria).to.have.property('size')
+			.that.is.a('number');
+		expect(filterCriteria).to.have.property('from')
+			.that.is.a('number');
+
+		done();
+	});
+
+	it('should build multiple normal where clause query without "and" for the WHERE filter', function (done) {
+		var criteria, size, offset, modelName, modelIdName;
+		criteria = {
+			where: {
+				role: 'lead',
+				vip: true
+			}
+		};
+		size = 100;
+		offset = 10;
+		modelName = 'MockLoopbackModel';
+		modelIdName = 'id';
+
+		var filterCriteria = testConnector.buildFilter(modelName, modelIdName, criteria, size, offset);
+		expect(filterCriteria).not.to.be.null;
+		expect(filterCriteria).to.have.property('index').that.is.a('string');
+		expect(filterCriteria).to.have.property('type').that.is.a('string').that.equals(modelName);
+		expect(filterCriteria).to.have.property('body')
+			.that.is.an('object')
+			.that.deep.equals({ // a. this is really 2 tests in one
+			sort: [
+				// b. `_uid` is an auto-generated field that ElasticSearch populates for us
+				// when we want to let the backend/system/ES take care of id population
+				// so if we want to sort by id, without specifying/controlling our own id field,
+				// then ofcourse the sort must happen on `_uid`, this part of the test, validates that!
+				'_uid'
+			],
+			query: {
+				bool: {
+					must: [
+						{
+							match: {
+								role: 'lead'
+							}
+						},
+						{
+							match: {
+								vip: true
+							}
+						}
+					]
+				}
+			}
+		});
+		expect(filterCriteria).to.have.property('size')
+			.that.is.a('number');
+		expect(filterCriteria).to.have.property('from')
+			.that.is.a('number');
+
+		done();
+	});
+
+	it('should build two "inq" and one "between" without "and" for the WHERE filter', function (done) {
+		var criteria, size, offset, modelName, modelIdName;
+		criteria = {
+			where: {
+				role: {inq: ['lead']},
+				order: {between: [1,6]},
+				id: {inq:  [2,3,4,5]}
+			}
+		};
+		size = 100;
+		offset = 10;
+		modelName = 'MockLoopbackModel';
+		modelIdName = 'id';
+
+		var filterCriteria = testConnector.buildFilter(modelName, modelIdName, criteria, size, offset);
+		expect(filterCriteria).not.to.be.null;
+		expect(filterCriteria).to.have.property('index').that.is.a('string');
+		expect(filterCriteria).to.have.property('type').that.is.a('string').that.equals(modelName);
+		expect(filterCriteria).to.have.property('body')
+			.that.is.an('object')
+			.that.deep.equals({ // a. this is really 2 tests in one
+			sort: [
+				// b. `_uid` is an auto-generated field that ElasticSearch populates for us
+				// when we want to let the backend/system/ES take care of id population
+				// so if we want to sort by id, without specifying/controlling our own id field,
+				// then ofcourse the sort must happen on `_uid`, this part of the test, validates that!
+				'_uid'
+			],
+			query: {
+				bool: {
+					must: [
+						{
+							terms: {
+								role: [
+									'lead'
+								]
+							}
+						},
+						{
+							range: {
+								order: {
+									gte: 1,
+									lte: 6
+								}
+							}
+						},
+						{
+							terms: {
+								_id: [
+									2,
+									3,
+									4,
+									5
+								]
 							}
 						}
 					]

--- a/test/02.basic-querying.test.js
+++ b/test/02.basic-querying.test.js
@@ -976,6 +976,52 @@ describe('basic-querying', function () {
 				});
 			},2000);
 		});
+
+		it('should support multiple comma separated property filter without "and" that is satisfied', function (done) {
+			setTimeout(function () {
+				User.find({where: {role: 'lead', vip: true}}, function (err, users) {
+					should.exist(users);
+					should.not.exist(err);
+					users.should.have.lengthOf(2);
+					done();
+				});
+			},2000);
+		});
+
+		it('should support multiple comma separated "inq" without "and" filter that is satisfied', function (done) {
+			setTimeout(function () {
+				User.find(
+					{
+						where: {
+							role: {inq: ['lead']},
+							seq: {inq: [0,2,3,4,5]}
+						}
+					}, function (err, users) {
+					should.exist(users);
+					should.not.exist(err);
+					users.should.have.lengthOf(1);
+					done();
+				});
+			},2000);
+		});
+
+		it('should support two "inq" and one "between" without "and" filter that is satisfied', function (done) {
+			setTimeout(function () {
+				User.find(
+					{
+						where: {
+							role: {inq: ['lead']},
+							order: {between: [1,6]},
+							seq: {inq:  [2,3,4,5]}
+						}
+					}, function (err, users) {
+					should.exist(users);
+					should.not.exist(err);
+					users.should.have.lengthOf(0);
+					done();
+				});
+			},2000);
+		});
 	});
 
 	// TODO: there is no way for us to test the connector code explicitly


### PR DESCRIPTION
Loopback internally does some model calls with where filter in a wrong pattern. Ideally where filter in loopback should just have single direct property filter and if there are multiple filters associated with the property then they all should be inside “and/ or” filter.