### PR TITLE
refresh: true v2

### DIFF
--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -48,6 +48,7 @@ var ESConnector = function (settings, dataSource) {
 	this.defaultSize = (settings.defaultSize || 10);
 	this.idField = 'id';
 	this.apiVersion = (settings.apiVersion || '2.x');
+    this.refreshOn = (settings.refreshOn || ['create', 'save', 'destroy', 'destroyAll', 'updateAttributes', 'updateOrCreate']);
 
 	this.debug = settings.debug || log.enabled;
 	if (this.debug) {
@@ -169,8 +170,8 @@ ESConnector.prototype.removeMappings = function (modelNames, callback) {
 	Promise.map(
 		mappingsToRemove,
 		function (mapping) {
-			var defaults = self.addDefaults(mapping.name);
-			log('ESConnector.prototype.removeMappings', 'calling self.db.indices.existsType()');
+            var defaults = self.addDefaults(mapping.name, 'removeMappings');
+            log('ESConnector.prototype.removeMappings', 'calling self.db.indices.existsType()');
 			return db.indices.existsType(defaults).then(function (exists) {
 				if (!exists) return Promise.resolve();
 				log('ESConnector.prototype.removeMappings', 'calling self.db.indices.deleteMapping()');
@@ -320,9 +321,10 @@ ESConnector.prototype.dataSourceToModel = function (modelName, data, idName) {
  * Add defaults such as index name and type
  *
  * @param {String} modelName
+ * @param {String} functionName The caller function name
  * @returns {object} Filter with index and type
  */
-ESConnector.prototype.addDefaults = function (modelName) {
+ESConnector.prototype.addDefaults = function (modelName, functionName) {
 	var self = this;
 	log('ESConnector.prototype.addDefaults', 'modelName:', modelName);
 
@@ -343,10 +345,21 @@ ESConnector.prototype.addDefaults = function (modelName) {
 	}
 	filter.type = typeFromDatasource || this.searchType || modelName;
 
-	var modelClass = this._models[modelName];
-	if (modelClass && _.isObject(modelClass.settings.elasticsearch)) {
-		_.extend(filter, modelClass.settings.elasticsearch);
+    // When changing data, wait until the change has been indexed so it is instantly available for search
+    if(this.refreshOn.indexOf(functionName) != -1) {
+        filter.refresh = true;
+    } else {
+		filter.refresh = false;
 	}
+
+    var modelClass = this._models[modelName];
+    if (modelClass && _.isObject(modelClass.settings.elasticsearch) && _.isObject(modelClass.settings.elasticsearch.settings)) {
+        _.extend(filter, modelClass.settings.elasticsearch.settings);
+    }
+
+    if (functionName && modelClass && _.isObject(modelClass.settings.elasticsearch) && _.isObject(modelClass.settings.elasticsearch[functionName])) {
+        _.extend(filter, modelClass.settings.elasticsearch[functionName]);
+    }
 
 	log('ESConnector.prototype.addDefaults', 'filter:', filter);
 	return filter;
@@ -372,7 +385,7 @@ ESConnector.prototype.buildFilter = function (modelName, idName, criteria, size,
 		throw new Error('idName not set!');
 	}
 
-	var filter = this.addDefaults(modelName);
+	var filter = this.addDefaults(modelName, 'buildFilter');
 	filter.body = {};
 
 	if (size !== undefined && size !== null) {
@@ -761,8 +774,8 @@ ESConnector.prototype.create = function (model, data, done) {
 	log('ESConnector.prototype.create', 'idName', idName, 'idValue', idValue);
 	//TODO: If model has custom id with generated false and if Id field is not prepopulated then create should fail.
 	//TODO: If model Id is not string and generated is true then create should fail because the auto generated es id is of type string and we cannot change it.
-	var document = self.addDefaults(model);
-	document[self.idField] = self.getDocumentId(idValue);
+    var document = self.addDefaults(model, 'create');
+    document[self.idField] = self.getDocumentId(idValue);
 	document.body = {};
 	_.assign(document.body, data);
 	log('ESConnector.prototype.create', 'document', document);
@@ -871,7 +884,7 @@ ESConnector.prototype.destroyAll = function destroyAll(modelName, whereClause, c
 		query: self.buildWhere(modelName, idName, whereClause).query
 	};
 
-	var defaults = self.addDefaults(modelName);
+	var defaults = self.addDefaults(modelName, 'destroyAll');
 	var options = _.defaults({body: body}, defaults);
 	log('ESConnector.prototype.destroyAll', 'options:', JSON.stringify(options, null, 2));
 	self.db.deleteByQuery(options)
@@ -917,7 +930,7 @@ ESConnector.prototype.count = function count(modelName, done, where) {
 			query: self.buildWhere(modelName, idName, where).query
 		};
 
-	var defaults = self.addDefaults(modelName);
+	var defaults = self.addDefaults(modelName, 'count');
 	self.db.count(_.defaults({body: body}, defaults)).then(
 		function (response) {
 			done(null, response.count);
@@ -957,7 +970,7 @@ ESConnector.prototype.find = function find(modelName, id, done) {
 		throw new Error('id not set!');
 	}
 
-	var defaults = self.addDefaults(modelName);
+	var defaults = self.addDefaults(modelName, 'find');
 	self.db.get(_.defaults({
 		id: self.getDocumentId(id)
 	}, defaults)).then(
@@ -984,7 +997,7 @@ ESConnector.prototype.destroy = function destroy(modelName, id, done) {
 		log('destroy', 'model', modelName, 'id', id);
 	}
 
-	var filter = self.addDefaults(modelName);
+	var filter = self.addDefaults(modelName, 'destroy');
 	filter[self.idField] = self.getDocumentId(id);
 	if (!filter[self.idField]) {
 		throw new Error('Document id not setted!');
@@ -1017,7 +1030,7 @@ ESConnector.prototype.updateAttributes = function updateAttrs(modelName, id, dat
 		throw new Error('id not set!');
 	}
 
-	var defaults = self.addDefaults(modelName);
+	var defaults = self.addDefaults(modelName, 'updateAttributes');
 	self.db.update(_.defaults({
 		id: id,
 		body: {
@@ -1053,7 +1066,7 @@ ESConnector.prototype.exists = function (modelName, id, done) {
 		throw new Error('id not set!');
 	}
 
-	var defaults = self.addDefaults(modelName);
+	var defaults = self.addDefaults(modelName, 'exists');
 	self.db.exists(_.defaults({
 		id: self.getDocumentId(id)
 	}, defaults)).then(
@@ -1093,7 +1106,7 @@ ESConnector.prototype.save = function (model, data, done) {
 	}
 
 	var idName = self.idName(model);
-	var defaults = self.addDefaults(model);
+	var defaults = self.addDefaults(model, 'save');
 	var id = self.getDocumentId(data[idName]);
 
 	if (id === undefined || id === null) {
@@ -1144,7 +1157,7 @@ ESConnector.prototype.updateOrCreate = function updateOrCreate(modelName, data, 
 		throw new Error('id not set!');
 	}
 
-	var defaults = self.addDefaults(modelName);
+	var defaults = self.addDefaults(modelName, 'updateOrCreate');
 	self.db.update(_.defaults({
 		id: id,
 		body: {

--- a/test/02.basic-querying.test.js
+++ b/test/02.basic-querying.test.js
@@ -4,7 +4,7 @@ var db, User, Customer, AccessToken, Post, PostWithId, Category, SubCategory;
 
 /*eslint no-console: "off"*/
 /*global getSchema should*/
-describe('basic-querying', function () {
+xdescribe('basic-querying', function () {
 
 	this.timeout(30000);
 

--- a/test/03.basic-querying-no-timeout.test.js
+++ b/test/03.basic-querying-no-timeout.test.js
@@ -1,0 +1,1371 @@
+require('./init.js');
+var async = require('async');
+var db, User, Customer, AccessToken, Post, PostWithId, Category, SubCategory;
+
+/*eslint no-console: "off"*/
+/*global getSchema should*/
+describe('basic-querying-no-timeout', function () {
+
+    before(function (done) {
+
+        this.timeout(4000);
+
+        // turn on additional logging
+        /*process.env.DEBUG += ',loopback:connector:*';
+         console.log('process.env.DEBUG: ' + process.env.DEBUG);*/
+
+        db = getSchema();
+        User = db.define('User', {
+            seq: {type: Number, index: true, id: true},
+            name: {type: String, index: true, sort: true},
+            email: {type: String, index: true},
+            birthday: {type: Date, index: true},
+            role: {type: String, index: true},
+            order: {type: Number, index: true, sort: true},
+            vip: {type: Boolean}
+        });
+
+        Customer = db.define('Customer',
+            {
+                objectId: {type: String, id: true, generated: false},
+                name: {type: String, index: true, sort: true},
+                email: {type: String, index: true},
+                birthday: {type: Date, index: true},
+                role: {type: String, index: true},
+                order: {type: Number, index: true, sort: true},
+                vip: {type: Boolean}
+            }/*,
+             {
+             // NOTE: overriding by specifying "datasource specific options" is possible
+             //       but not recommended for index and type because the timing for setting them up
+             //       becomes tricky. It is better to provide them in the `mappings` property
+             //       of datasource.<env>.json file
+             elasticsearch: {
+             index: 'juju',
+             type: 'consumer' // could set override here
+             }
+             }*/
+        );
+
+        AccessToken = db.define('AccessToken', {
+            ttl: {
+                type: Number,
+                ttl: true,
+                default: 1209600,
+                description: "time to live in seconds (2 weeks by default)"
+            },
+            created: {
+                type: Date
+            }
+        });
+
+        Post = db.define('Post', {
+            title: {type: String, length: 255},
+            content: {type: String},
+            comments: [String]
+        }, {
+            elasticsearch: {
+                type: 'PostCollection' // Customize the collection name
+            },
+            forceId: false
+        });
+
+        PostWithId = db.define('PostWithId', {
+            id: {type: String, id: true},
+            title: {type: String, length: 255},
+            content: {type: String}
+        });
+
+        Category = db.define('Category', {
+            category_name: {type: String, index: true, sort: true},
+            desc: {type: String, length: 100}
+        });
+
+        SubCategory = db.define('SubCategory', {
+            subcategory_name: {type: String}
+        });
+
+        Category.embedsMany(SubCategory, {
+            options: {
+                "validate": true,
+                "forceId": false,
+                "persistent": true
+            }
+        });
+
+
+        //TODO: add tests for a model where type doesn't match its name
+        // Added few test for model Post with type name as PostCollection in `save` block test cases.
+
+        // no big reason to delay this ...
+        // just want to give the feel that getSchema and automigrate are sequential actions
+        db.automigrate(done);
+
+    });
+
+    describe('ping', function () {
+        it('should be able to test connections', function (done) {
+            db.ping(function (err) {
+                should.not.exist(err);
+                done();
+            });
+        });
+    });
+
+    describe('for a model with string IDs', function () {
+
+        beforeEach(seedCustomers);
+
+        it('should work for findById', function (done) {
+            Customer.findById('aaa', function (err, customer) {
+                should.exist(customer);
+                should.not.exist(err);
+                console.log(customer);
+                done();
+            });
+
+        });
+
+        it('should work for updateAttributes', function (done) {
+            var updateAttrs = {newField: 1, order: 999};
+            Customer.findById('aaa', function (err, customer) {
+                should.not.exist(err);
+                should.exist(customer);
+                should.exist(customer.order);
+                should.not.exist(customer.newField);
+                customer.updateAttributes(updateAttrs, function (err, updatedCustomer) {
+                    should.not.exist(err);
+                    should.exist(updatedCustomer);
+                    should.exist(updatedCustomer.order);
+                    updatedCustomer.order.should.equal(updateAttrs.order);
+                    // TODO: should a new field be added by updateAttributes?
+                    // https://support.strongloop.com/requests/680
+                    should.exist(updatedCustomer.newField);
+                    updatedCustomer.newField.should.equal(updateAttrs.newField);
+
+                    Customer.findById('aaa', function (err, customerFetchedAgain) {
+                        should.not.exist(err);
+                        should.exist(customerFetchedAgain);
+                        should.exist(customerFetchedAgain.order);
+                        customerFetchedAgain.order.should.equal(updateAttrs.order);
+                        // TODO: should a new field be added by updateAttributes?
+                        // https://support.strongloop.com/requests/680
+                        should.exist(customerFetchedAgain.newField);
+                        customerFetchedAgain.newField.should.equal(updateAttrs.newField);
+                        done();
+                    });
+
+                });
+            });
+
+        });
+    });
+
+    describe('findById', function () {
+
+        before(function (done) {
+            User.destroyAll(done);
+        });
+
+        it('should query by id: not found', function (done) {
+            // TODO: wait a few seconds for the Users to be destroyed? near-real-time != real-time
+            User.findById(1, function (err, u) {
+                should.not.exist(u);
+                should.not.exist(err);
+                done();
+            });
+        });
+
+        it('should query by id: found', function (done) {
+            User.create(function (err, u) {
+                should.not.exist(err);
+                should.exist(u.id);
+                User.findById(u.id, function (err, u) {
+                    console.log('err: ', err);
+                    console.log('user: ', u);
+                    should.exist(u);
+                    should.not.exist(err);
+                    u.should.be.an.instanceOf(User);
+                    done();
+                });
+            });
+        });
+
+    });
+
+    describe('custom', function () {
+
+        it('suggests query should work', function (done) {
+            User.all({
+                suggests: {
+                    'title_suggester': {
+                        text: 'd',
+                        term: {
+                            field: 'name'
+                        }
+                    }
+                }
+            }, function (err/*, u*/) {
+                //should.exist(u);
+                should.not.exist(err);
+                done();
+            });
+        });
+
+        it('native query should work', function (done) {
+            User.all({
+                native: {
+                    query: {
+                        'match_all': {}
+                    }
+                }
+            }, function (err, u) {
+                should.exist(u);
+                should.not.exist(err);
+                done();
+            });
+        });
+    });
+
+    // TODO: Resolve the discussion around: https://support.strongloop.com/requests/676
+    describe('findByIds', function () {
+        var createdUsers;
+        before(function (done) {
+            var people = [
+                {seq: 1, name: 'a', vip: true},
+                {seq: 2, name: 'b'},
+                {seq: 3, name: 'c'},
+                {seq: 4, name: 'd', vip: true},
+                {seq: 5, name: 'e'},
+                {seq: 6, name: 'f'}
+            ];
+            db.automigrate(['User'], function (err) {
+                should.not.exist(err);
+                User.create(people, function (err, users) {
+                    should.not.exist(err);
+                    // Users might be created in parallel and the generated ids can be
+                    // out of sequence
+                    createdUsers = users;
+                    done();
+                });
+            });
+        });
+
+        it('should query by ids', function (done) {
+            User.findByIds(
+                [createdUsers[2].id, createdUsers[1].id, createdUsers[0].id],
+                function (err, users) {
+                    should.exist(users);
+                    should.not.exist(err);
+                    var names = users.map(function (u) {
+                        return u.name;
+                    });
+
+                    // TODO: 1. find code that tries to add sort order and tell it not to do so
+                    //          because findByIds isn't meant to work like that
+                    //       2. can get clues from how mongo connector tracks the calling
+                    //          method name to accomplish the same thing
+
+                    // TODO: Resolve the discussion around: https://support.strongloop.com/requests/676
+                    /**
+                     * 1) find() by default sorts by id property.
+                     * 2) findByIds() expects the results sorted by the ids as they are passed in the argument.
+                     *    i) Connector.prototype.all() should NOT deal with the rules for findByIds()
+                     *       as the sorting for findByIds() is done after the connector returned an array of objects.
+                     *    ii) Here is how findByIds() implemented:
+                     *        i) Build a query with inq for ids from the arg
+                     *        ii) Call Model.find() (no ordering is set, connectors will default it to id)
+                     *        iii) Sort the results by the order of ids in the arg
+                     *
+                     */
+                    /*names.should.eql( // NOTE: order doesn't add up, is 2.ii.iii broken?
+                     [createdUsers[2].name, createdUsers[1].name, createdUsers[0].name]);*/
+
+                    // temporary workaround to help tests pass
+                    names.should.include(createdUsers[2].name);
+                    names.should.include(createdUsers[1].name);
+                    names.should.include(createdUsers[0].name);
+                    done();
+                });
+        });
+
+        it('should query by ids and condition', function (done) {
+
+            User.findByIds([
+                    createdUsers[0].id,
+                    createdUsers[1].id,
+                    createdUsers[2].id,
+                    createdUsers[3].id], // this helps test "inq"
+                {where: {vip: true}}, function (err, users) {
+                    should.exist(users);
+                    should.not.exist(err);
+                    var names = users.map(function (u) {
+                        return u.name;
+                    });
+                    names.should.eql(createdUsers.slice(0, 4).filter(function (u) {
+                        return u.vip;
+                    }).map(function (u) {
+                        return u.name;
+                    }));
+                    done();
+                });
+
+        });
+
+    });
+
+    describe('sanity test IDs', function () {
+
+        before(function (done) {
+            User.destroyAll(done);
+        });
+
+        it('should auto generate an id', function (done) {
+
+            User.create(function (err, u) {
+                should.not.exist(err);
+                should.exist(u.id);
+                should.exist(u.seq);
+                done();
+            });
+        });
+
+        it('should use specified id', function (done) {
+
+            User.create({seq: 666}, function (err, u) {
+                should.not.exist(err);
+                should.exist(u.id);
+                should.exist(u.seq);
+                u.id.should.equal('666');
+                u.seq.should.equal('666');
+                done();
+            });
+        });
+
+        after(function (done) {
+            db.automigrate(done);
+        });
+    });
+
+    describe('find', function () {
+
+        before(seed);
+
+        it('should query collection', function (done) {
+
+            User.find(function (err, users) {
+                should.exist(users);
+                should.not.exist(err);
+                users.should.have.lengthOf(6);
+                done();
+            });
+
+        });
+
+        it('should query limited collection', function (done) {
+            User.find({limit: 3}, function (err, users) {
+                should.exist(users);
+                should.not.exist(err);
+                users.should.have.lengthOf(3);
+                done();
+            });
+        });
+
+        it('should query ordered collection with skip & limit', function (done) {
+            User.find({skip: 1, limit: 4, order: 'seq'}, function (err, users) {
+                should.exist(users);
+                should.not.exist(err);
+                users[0].seq.should.be.eql(1);
+                users.should.have.lengthOf(4);
+                done();
+            });
+        });
+
+        it('should query ordered collection with offset & limit', function (done) {
+            User.find({offset: 2, limit: 3, order: 'seq'}, function (err, users) {
+                should.exist(users);
+                should.not.exist(err);
+                users[0].seq.should.be.eql(2);
+                users.should.have.lengthOf(3);
+                done();
+            });
+        });
+
+        it('should query filtered collection', function (done) {
+            User.find({where: {role: 'lead'}}, function (err, users) {
+                should.exist(users);
+                should.not.exist(err);
+                users.should.have.lengthOf(2);
+                done();
+            });
+        });
+
+        it('should query collection sorted by numeric field', function (done) {
+            User.find({order: 'order'}, function (err, users) {
+                should.exist(users);
+                should.not.exist(err);
+                users.forEach(function (u, i) {
+                    u.order.should.eql(i + 1);
+                });
+                done();
+            });
+        });
+
+        it('should query collection desc sorted by numeric field', function (done) {
+            User.find({order: 'order DESC'}, function (err, users) {
+                should.exist(users);
+                should.not.exist(err);
+                users.forEach(function (u, i) {
+                    u.order.should.eql(users.length - i);
+                });
+                done();
+            });
+        });
+
+        it('should query collection sorted by string field', function (done) {
+            User.find({order: 'name'}, function (err, users) {
+                should.exist(users);
+                should.not.exist(err);
+                users.shift().name.should.equal('George Harrison');
+                users.shift().name.should.equal('John Lennon');
+                users.pop().name.should.equal('Stuart Sutcliffe');
+                done();
+            });
+        });
+
+        it('should query collection desc sorted by string field', function (done) {
+            User.find({order: 'name DESC'}, function (err, users) {
+                should.exist(users);
+                should.not.exist(err);
+                users.pop().name.should.equal('George Harrison');
+                users.pop().name.should.equal('John Lennon');
+                users.shift().name.should.equal('Stuart Sutcliffe');
+                done();
+            });
+        });
+
+        it('should support "and" operator that is satisfied', function (done) {
+            User.find({
+                where: {
+                    and: [
+                        {name: 'John Lennon'},
+                        {role: 'lead'}
+                    ]
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 1);
+                done();
+            });
+        });
+
+        it('should support "and" operator that is not satisfied', function (done) {
+            User.find({
+                where: {
+                    and: [
+                        {name: 'John Lennon'},
+                        {role: 'member'}
+                    ]
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 0);
+                done();
+            });
+        });
+
+        it('should support "or" that is satisfied', function (done) {
+            User.find({
+                where: {
+                    or: [
+                        {name: 'John Lennon'},
+                        {role: 'lead'}
+                    ]
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 2);
+                done();
+            });
+        });
+
+        it('should support "or" operator that is not satisfied', function (done) {
+            User.find({
+                where: {
+                    or: [
+                        {name: 'XYZ'},
+                        {role: 'Hello1'}
+                    ]
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 0);
+                done();
+            });
+        });
+
+        it('should support date "gte" that is satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    birthday: {"gte": new Date('1980-12-08')}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 1);
+                users[0].name.should.equal('John Lennon');
+                done();
+            });
+        });
+
+        it('should support date "gt" that is not satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    birthday: {"gt": new Date('1980-12-08')}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 0);
+                done();
+            });
+        });
+
+        it('should support date "gt" that is satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    birthday: {"gt": new Date('1980-12-07')}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 1);
+                users[0].name.should.equal('John Lennon');
+                done();
+            });
+        });
+
+        it('should support date "lt" that is satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    birthday: {"lt": new Date('1980-12-07')}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 1);
+                users[0].name.should.equal('Paul McCartney');
+                done();
+            });
+        });
+
+        it('should support number "gte" that is satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    order: {"gte": 3}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 4);
+                users[0].name.should.equal('George Harrison');
+                done();
+            });
+        });
+
+        it('should support number "gt" that is not satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    order: {"gt": 6}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 0);
+                done();
+            });
+        });
+
+        it('should support number "gt" that is satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    order: {"gt": 5}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 1);
+                users[0].name.should.equal('Ringo Starr');
+                done();
+            });
+        });
+
+        it('should support number "lt" that is satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    order: {"lt": 2}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 1);
+                users[0].name.should.equal('Paul McCartney');
+                done();
+            });
+        });
+
+        xit('should support number "gt" that is satisfied by null value', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    order: {"gt": null}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 0);
+                done();
+            });
+        });
+
+        xit('should support number "lt" that is not satisfied by null value', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    order: {"lt": null}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 0);
+                done();
+            });
+        });
+
+        xit('should support string "gte" that is satisfied by null value', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    name: {"gte": null}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 0);
+                done();
+            });
+        });
+
+        it('should support string "gte" that is satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    name: {"gte": 'Paul McCartney'}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 4);
+                users[0].name.should.equal('Paul McCartney');
+                done();
+            });
+        });
+
+        it('should support string "gt" that is not satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    name: {"gt": 'xyz'}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 0);
+                done();
+            });
+        });
+
+        it('should support string "gt" that is satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    name: {"gt": 'Paul McCartney'}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 3);
+                users[0].name.should.equal('Ringo Starr');
+                done();
+            });
+        });
+
+        it('should support string "lt" that is satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    name: {"lt": 'Paul McCartney'}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 2);
+                users[0].name.should.equal('John Lennon');
+                done();
+            });
+        });
+
+        it('should support boolean "gte" that is satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    vip: {"gte": true}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 3);
+                users[0].name.should.equal('John Lennon');
+                done();
+            });
+        });
+
+        it('should support boolean "gt" that is not satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    vip: {"gt": true}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 0);
+                done();
+            });
+        });
+
+        it('should support boolean "gt" that is satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    vip: {"gt": false}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 3);
+                users[0].name.should.equal('John Lennon');
+                done();
+            });
+        });
+
+        it('should support boolean "lt" that is satisfied', function (done) {
+            User.find({
+                order: 'seq', where: {
+                    vip: {"lt": true}
+                }
+            }, function (err, users) {
+                should.not.exist(err);
+                users.should.have.property('length', 2);
+                users[0].name.should.equal('George Harrison');
+                done();
+            });
+        });
+
+    });
+
+    // TODO: there is no way for us to test the connector code explicitly
+    //       if the underlying juggler performs the same work as well!
+    //       https://support.strongloop.com/requests/679
+    //       https://github.com/strongloop-community/loopback-connector-elastic-search/issues/5
+    describe('find', function () {
+
+        before(seed);
+
+        it('should only include fields as specified', function (done) {
+            // NOTE: ES indexing then searching isn't real-time ... its near-real-time
+            var remaining = 0;
+
+            function sample(fields) {
+                console.log('expect: ', fields);
+                return {
+                    expect: function (arr) {
+                        remaining++;
+                        User.find({fields: fields}, function (err, users) {
+
+                            remaining--;
+                            if (err) {
+                                return done(err);
+                            }
+
+                            should.exist(users);
+                            console.log(JSON.stringify(users, null, 2));
+
+                            if (remaining === 0) {
+                                done();
+                            }
+
+                            users.forEach(function (user) {
+                                var obj = user.toObject();
+                                Object.keys(obj)
+                                    .forEach(function (key) {
+                                        // if the obj has an unexpected value
+                                        if (obj[key] !== undefined && arr.indexOf(key) === -1) {
+                                            throw new Error('should not include data for key: ' + key);
+                                        }
+                                    });
+                            });
+                        });
+                    }
+                };
+            }
+
+            sample({email: false}).expect(['id', 'seq', 'name', 'role', 'order', 'birthday', 'vip']);
+            /*sample({name: true}).expect(['name']);
+             sample({name: false}).expect(['id', 'seq', 'email', 'role', 'order', 'birthday', 'vip']);
+             sample({name: false, id: true}).expect(['id']);
+             sample({id: true}).expect(['id']);
+             sample('id').expect(['id']);
+             sample(['id']).expect(['id']);
+             sample(['email']).expect(['email']);*/
+        }, 2000);
+    });
+
+});
+
+describe('count', function () {
+
+    before(seed);
+
+    it('should query total count', function (done) {
+        // NOTE: ES indexing then searching isn't real-time ... its near-real-time
+        User.count(function (err, n) {
+            should.not.exist(err);
+            should.exist(n);
+            n.should.equal(6);
+            done();
+        });
+    });
+
+    it('should query filtered count', function (done) {
+        User.count({role: 'lead'}, function (err, n) {
+            should.not.exist(err);
+            should.exist(n);
+            n.should.equal(2);
+            done();
+        });
+    });
+});
+
+describe('findOne', function () {
+
+    before(seed);
+
+    it('should find first record (default sort by id)', function (done) {
+        User.all({order: 'id'}, function (err, users) {
+            User.findOne(function (e, u) {
+                should.not.exist(e);
+                should.exist(u);
+                // NOTE: if `id: true` is not set explicitly when defining a model, there will be trouble!
+                u.id.toString().should.equal(users[0].id.toString());
+                done();
+            });
+        });
+    });
+
+    it('should find first record', function (done) {
+        User.findOne({order: 'order'}, function (e, u) {
+            should.not.exist(e);
+            should.exist(u);
+            u.order.should.equal(1);
+            u.name.should.equal('Paul McCartney');
+            done();
+        });
+    });
+
+    it('should find last record', function (done) {
+        User.findOne({order: 'order DESC'}, function (e, u) {
+            should.not.exist(e);
+            should.exist(u);
+            u.order.should.equal(6);
+            u.name.should.equal('Ringo Starr');
+            done();
+        });
+    });
+
+    it('should find last record in filtered set', function (done) {
+        User.findOne({
+            where: {role: 'lead'},
+            order: 'order DESC'
+        }, function (e, u) {
+            should.not.exist(e);
+            should.exist(u);
+            u.order.should.equal(2);
+            u.name.should.equal('John Lennon');
+            done();
+        });
+    });
+
+    it('should work even when find by id', function (done) {
+        User.findOne(function (e, u) {
+            //console.log(JSON.stringify(u));
+            // ESConnector.prototype.all +0ms model User filter {"where":{},"limit":1,"offset":0,"skip":0}
+            /*
+             * Ideally, instead of always generating:
+             *   filter {"where":{"id":0},"limit":1,"offset":0,"skip":0}
+             * the id-literal should be replaced with the actual idName by loopback's core:
+             *   filter {"where":{"seq":0},"limit":1,"offset":0,"skip":0}
+             * in my opinion.
+             */
+            User.findOne({where: {id: u.id}}, function (err, user) {
+                should.not.exist(err);
+                should.exist(user);
+                done();
+            });
+        });
+    });
+
+});
+
+describe('exists', function () {
+
+    before(seed);
+
+    it('should check whether record exist', function (done) {
+
+        // NOTE: ES indexing then searching isn't real-time ... its near-real-time
+        User.findOne(function (e, u) {
+            User.exists(u.id, function (err, exists) {
+                should.not.exist(err);
+                should.exist(exists);
+                exists.should.be.ok;
+                done();
+            });
+        });
+
+    });
+
+    it('should check whether record not exist', function (done) {
+        User.destroyAll(function () {
+            User.exists(42, function (err, exists) {
+                should.not.exist(err);
+                exists.should.not.be.ok;
+                done();
+            });
+        });
+    });
+
+});
+
+describe('destroyAll with where option', function () {
+
+    before(seed);
+
+    it('should only delete instances that satisfy the where condition', function (done) {
+        this.timeout(6000);
+        setTimeout(function () {
+            User.destroyAll({name: 'John Lennon'}, function () {
+                setTimeout(function () {
+                    User.find({where: {name: 'John Lennon'}}, function (err, data) {
+                        should.not.exist(err);
+                        data.length.should.equal(0);
+                        User.find({where: {name: 'Paul McCartney'}}, function (err, data) {
+                            should.not.exist(err);
+                            data.length.should.equal(1);
+                            done();
+                        });
+                    });
+                }, 2000);
+            });
+        }, 2000);
+    });
+});
+
+describe('updateOrCreate', function () {
+
+    beforeEach(seed);
+
+    it('should update existing model', function (done) {
+
+        var beatle = {seq: 1, rating: 5};
+        User.updateOrCreate(beatle, function (err, instance) {
+            should.not.exist(err);
+            should.exist(instance);
+            //instance.should.eql(beatle);
+            User.find({where: {seq: 1}}, function (err, data) {
+                should.not.exist(err);
+                //data.length.should.equal(0);
+                data[0].rating.should.equal(beatle.rating);
+                done();
+            });
+        });
+    });
+
+    it('should create a new model', function (done) {
+        // NOTE: ES indexing then searching isn't real-time ... its near-real-time
+        var beatlesFan = {seq: 6, name: 'Pulkit Singhal', order: 7, vip: false};
+        User.updateOrCreate(beatlesFan, function (err, instance) {
+            should.not.exist(err);
+            should.exist(instance);
+            should.exist(instance.id);
+            should.exist(instance.seq);
+            User.find({where: {seq: instance.seq}}, function (err, data) {
+                should.not.exist(err);
+                data[0].seq.should.equal(beatlesFan.seq);
+                data[0].name.should.equal(beatlesFan.name);
+                data[0].order.should.equal(beatlesFan.order);
+                data[0].vip.should.equal(beatlesFan.vip);
+                done();
+            });
+        });
+    });
+});
+
+describe('updateAttributes', function () {
+
+    beforeEach(seed);
+
+    it('should update existing model', function (done) {
+        var updateAttrs = {newField: 1, order: 999};
+        User.findById(1, function (err, user) {
+            should.not.exist(err);
+            should.exist(user);
+            //user.id.should.equal(1);
+            //user.seq.should.equal(1);
+            should.exist(user.order);
+            should.not.exist(user.newField);
+            user.updateAttributes(updateAttrs, function (err, updatedUser) {
+                should.not.exist(err);
+                should.exist(updatedUser);
+                should.exist(updatedUser.order);
+                updatedUser.order.should.equal(updateAttrs.order);
+                // TODO: should a new field be added by updateAttributes?
+                // https://support.strongloop.com/requests/680
+                should.exist(updatedUser.newField);
+                updatedUser.newField.should.equal(updateAttrs.newField);
+                User.findById(1, function (err, userFetchedAgain) {
+                    should.not.exist(err);
+                    should.exist(userFetchedAgain);
+                    should.exist(userFetchedAgain.order);
+                    userFetchedAgain.order.should.equal(updateAttrs.order);
+                    // TODO: should a new field be added by updateAttributes?
+                    // https://support.strongloop.com/requests/680
+                    should.exist(userFetchedAgain.newField);
+                    userFetchedAgain.newField.should.equal(updateAttrs.newField);
+                    done();
+                });
+            });
+        });
+    });
+
+});
+
+describe('all', function () {
+
+    before(destroyAccessTokens);
+
+    it('should convert date type fields from string to javascript date object when fetched', function (done) {
+        AccessToken.create({ttl: 1209600, created: '2017-01-10T12:12:38.600Z'}, function (err, token) {
+            should.not.exist(err);
+            should.exist(token.id);
+            AccessToken.findById(token.id, function (err, tokenInstance) {
+                should.not.exist(err);
+                should.exist(tokenInstance);
+                tokenInstance.should.be.an.instanceOf(AccessToken);
+                tokenInstance.created.should.be.an.instanceOf(Date);
+                done();
+            });
+        });
+    });
+
+    describe('embedsMany relations', function () {
+
+        before(function (done) {
+            Category.destroyAll(function () {
+                SubCategory.destroyAll(function () {
+                    db.automigrate(['Category'], done);
+                });
+            });
+        });
+
+        it('should create embeded models and return embeded data using findById', function (done) {
+            var category = {category_name: 'Apparels', desc: 'This is a category for apparels'};
+            Category.create(category, function (err, ct) {
+                should.not.exist(err);
+                should.exist(ct.id);
+                should.exist(ct.category_name);
+                should.exist(ct.desc);
+                ct.subCategoryList.create({subcategory_name: 'Jeans'}, function (err, sct) {
+                    should.not.exist(err);
+                    should.exist(sct.id);
+                    expect(sct.subcategory_name).to.equal('Jeans');
+                    Category.findById(ct.id, function (err, found) {
+                        should.not.exist(err);
+                        should.exist(found.id);
+                        expect(found.category_name).to.equal('Apparels');
+                        expect(found.subCategories).to.be.instanceOf(Array);
+                        expect(found).to.have.deep.property('subCategories[0].subcategory_name', 'Jeans');
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('should create multiple embeded models and return proper data using findById', function (done) {
+            var category = {category_name: 'Electronics', desc: 'This is a category for electronics'};
+            Category.create(category, function (err, ct) {
+                should.not.exist(err);
+                should.exist(ct.id);
+                should.exist(ct.category_name);
+                should.exist(ct.desc);
+                ct.subCategoryList.create({subcategory_name: 'Mobiles'}, function (err, sct) {
+                    should.not.exist(err);
+                    should.exist(sct.id);
+                    expect(sct.subcategory_name).to.equal('Mobiles');
+                    ct.subCategoryList.create({subcategory_name: 'Laptops'}, function (err, data) {
+                        should.not.exist(err);
+                        should.exist(data.id);
+                        expect(data.subcategory_name).to.equal('Laptops');
+                        Category.findById(ct.id, function (err, found) {
+                            should.not.exist(err);
+                            should.exist(found.id);
+                            expect(found.category_name).to.equal('Electronics');
+                            expect(found.subCategories).to.be.instanceOf(Array);
+                            expect(found).to.have.deep.property('subCategories[0].subcategory_name', 'Mobiles');
+                            expect(found).to.have.deep.property('subCategories[1].subcategory_name', 'Laptops');
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+
+        it('should create embeded models and return embeded data using find', function (done) {
+            var category = {category_name: 'Footwear', desc: 'This is a category for footwear'};
+            Category.create(category, function (err, ct) {
+                should.not.exist(err);
+                should.exist(ct.id);
+                should.exist(ct.category_name);
+                should.exist(ct.desc);
+                ct.subCategoryList.create({subcategory_name: 'Sandals'}, function (err, sct) {
+                    should.not.exist(err);
+                    should.exist(sct.id);
+                    expect(sct.subcategory_name).to.equal('Sandals');
+                    Category.find({where: {category_name: 'Footwear'}}, function (err, found) {
+                        found = found[0];
+                        should.not.exist(err);
+                        should.exist(found.id);
+                        expect(found.category_name).to.equal('Footwear');
+                        expect(found.subCategories).to.be.instanceOf(Array);
+                        expect(found).to.have.deep.property('subCategories[0].subcategory_name', 'Sandals');
+                        done();
+                    });
+                });
+            });
+        });
+    });
+});
+
+describe('save', function () {
+
+    before(destroyPosts);
+
+    it('all return should honor filter.fields, with `_id` as defined id', function (done) {
+
+        var post = new PostWithId({id: 'AAAA', title: 'Posts', content: 'all return should honor filter.fields'});
+        post.save(function (err, post) {
+            PostWithId.all({fields: ['title'], where: {title: 'Posts'}}, function (err, posts) {
+                should.not.exist(err);
+                posts.should.have.lengthOf(1);
+                post = posts[0];
+                post.should.have.property('title', 'Posts');
+                post.should.have.property('content', undefined);
+                should.not.exist(post._id);
+
+                done();
+            });
+        });
+    });
+
+    it('save should not return _id', function (done) {
+
+        Post.create({title: 'Post1', content: 'Post content'}, function (err, post) {
+            post.content = 'AAA';
+            post.save(function (err, p) {
+                should.not.exist(err);
+                should.not.exist(p._id);
+                p.id.should.be.equal(post.id);
+                p.content.should.be.equal('AAA');
+
+                done();
+            });
+
+        });
+    });
+
+    it('save should update the instance with the same id', function (done) {
+
+        Post.create({title: 'a', content: 'AAA'}, function (err, post) {
+            post.title = 'b';
+            delete post.content;
+            post.save(function (err, p) {
+                should.not.exist(err);
+                p.id.should.be.equal(post.id);
+                p.content.should.be.equal(post.content);
+                should.not.exist(p._id);
+                Post.findById(post.id, function (err, p) {
+                    p.id.should.be.eql(post.id);
+                    should.not.exist(p._id);
+                    p.content.should.be.equal(post.content);
+                    p.title.should.be.equal('b');
+                    done();
+                });
+            });
+        });
+    });
+
+    it('save should update the instance without removing existing properties', function (done) {
+
+        Post.create({
+            title: 'a',
+            content: 'update the instance without removing existing properties'
+        }, function (err, post) {
+            delete post.title;
+            post.save(function (err, p) {
+
+                should.not.exist(err);
+                p.id.should.be.equal(post.id);
+                p.content.should.be.equal(post.content);
+                should.not.exist(p._id);
+                Post.findById(post.id, function (err, p) {
+                    p.id.should.be.eql(post.id);
+                    should.not.exist(p._id);
+                    p.content.should.be.equal(post.content);
+                    p.title.should.be.equal('a');
+
+                    done();
+                });
+
+            });
+        });
+
+        it('save should create a new instance if it does not exist', function (done) {
+
+            var post = new Post({id: '123', title: 'Create', content: 'create if does not exist'});
+            post.save(post, function (err, p) {
+                should.not.exist(err);
+                p.title.should.be.equal(post.title);
+                p.content.should.be.equal(post.content);
+                p.id.should.be.equal(post.id);
+                Post.findById(p.id, function (err, p) {
+                    p.id.should.be.equal(post.id);
+                    should.not.exist(p._id);
+                    p.content.should.be.equal(post.content);
+                    p.title.should.be.equal(post.title);
+                    p.id.should.be.equal(post.id);
+
+                    done();
+                });
+            });
+        });
+
+        it('all return should honor filter.fields', function (done) {
+
+            var post = new Post({title: 'Fields', content: 'all return should honor filter.fields'});
+            post.save(function (err, post) {
+                Post.all({fields: ['title'], where: {title: 'Fields'}}, function (err, posts) {
+                    should.not.exist(err);
+                    posts.should.have.lengthOf(1);
+                    post = posts[0];
+                    post.should.have.property('title', 'Fields');
+                    post.should.have.property('content', undefined);
+                    should.not.exist(post._id);
+                    should.not.exist(post.id);
+
+                    done();
+                });
+            });
+        });
+
+    });
+
+    xdescribe('test id fallback when `generated:false`', function () {
+
+        it('should auto generate an id', function (done) {
+            Customer.create({name: 'George Harrison', vip: false}, function (err, u) {
+                console.log('user after create', u);
+                should.not.exist(err);
+                should.exist(u.id);
+                should.exist(u.objectId);
+                Customer.findById(u.objectId, function (err, u) {
+                    console.log('customer after first findById', u);
+                    u.save(function (err, savedCustomer) {
+                        console.log('user after save', savedCustomer);
+                        Customer.findById(u.objectId, function (err, foundUser) {
+                            console.log('user after findById', foundUser);
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+});
+
+function seed(done) {
+
+    var beatles = [
+        {
+            seq: 0,
+            name: 'John Lennon',
+            email: 'john@b3atl3s.co.uk',
+            role: 'lead',
+            birthday: new Date('1980-12-08'),
+            order: 2,
+            vip: true
+        },
+        {
+            seq: 1,
+            name: 'Paul McCartney',
+            email: 'paul@b3atl3s.co.uk',
+            role: 'lead',
+            birthday: new Date('1942-06-18'),
+            order: 1,
+            vip: true
+        },
+        {seq: 2, name: 'George Harrison', order: 5, vip: false},
+        {seq: 3, name: 'Ringo Starr', order: 6, vip: false},
+        {seq: 4, name: 'Pete Best', order: 4},
+        {seq: 5, name: 'Stuart Sutcliffe', order: 3, vip: true}
+    ];
+
+    User.destroyAll(function(){
+        User.create(beatles, function() {
+            done();
+        });
+    });
+}
+
+function seedCustomers(done) {
+    this.timeout(4000);
+    var customers = [
+        {
+            objectId: 'aaa',
+            name: 'John Lennon',
+            email: 'john@b3atl3s.co.uk',
+            role: 'lead',
+            birthday: new Date('1980-12-08'),
+            order: 2,
+            vip: true
+        },
+        {
+            objectId: 'bbb',
+            name: 'Paul McCartney',
+            email: 'paul@b3atl3s.co.uk',
+            role: 'lead',
+            birthday: new Date('1942-06-18'),
+            order: 1,
+            vip: true
+        },
+        {objectId: 'ccc', name: 'George Harrison', order: 5, vip: false},
+        {objectId: 'ddd', name: 'Ringo Starr', order: 6, vip: false},
+        {objectId: 'eee', name: 'Pete Best', order: 4},
+        {objectId: 'fff', name: 'Stuart Sutcliffe', order: 3, vip: true}
+    ];
+
+    return Customer.destroyAll().then(function() {
+        Customer.create(customers, function(err, customer) {
+            done();
+        });
+    });
+}
+
+function destroyAccessTokens(done) {
+    this.timeout(4000);
+    AccessToken.destroyAll.bind(AccessToken);
+    setTimeout(function () {
+        done();
+    }, 2000);
+}
+
+function destroyPosts(done) {
+    this.timeout(4000);
+    Post.destroyAll.bind(Post);
+    PostWithId.destroyAll.bind(PostWithId);
+    setTimeout(function () {
+        done();
+    }, 2000)
+}

--- a/test/04.add-defaults-refresh-true.test.js
+++ b/test/04.add-defaults-refresh-true.test.js
@@ -1,0 +1,90 @@
+/*eslint no-console: "off"*/
+/*global getSchema should assert*/
+describe('Add Defaults', function () {
+    var testConnector, testConnector2, db, db2;
+
+    before(function (done) {
+        require('./init.js');
+        var settings = getSettings();
+        settings.log = 'error';
+        db = getDataSource(settings);
+        db2 = getDataSource({
+            "name": "esv2-plain",
+            "connector": "elasticsearch",
+            "apiVersion": "2.3",
+            "refreshOn": ["save", "updateAttributes"]
+        });
+        var account = {real_name: {type: String, index: true, sort: true}};
+        db2.define("Account", account);
+        db.define("Account", account);
+        var bookProps = {real_name: {type: String, index: true, sort: true}};
+        var bookSettings = {
+            "properties": {
+                "real_name": {
+                    "type": "keyword"
+                }
+            },
+            "elasticsearch": {
+                "create": {
+                    "refresh": false
+                },
+                "destroy": {
+                    "refresh": false
+                },
+                "destroyAll": {
+                    "refresh": "wait_for"
+                }
+            }
+        };
+        db.define("Book", bookProps, bookSettings);
+        db2.define("Book", bookProps, bookSettings);
+        testConnector = db.connector;
+        testConnector2 = db2.connector;
+        db.automigrate(done);
+    });
+
+    describe('Datasource specific settings', function () {
+
+        it('modifying operations should have refresh true', function () {
+            (testConnector2.addDefaults('Account', 'create').refresh === false).should.be.true;
+            (testConnector2.addDefaults('Account', 'save').refresh === true).should.be.true;
+            (testConnector2.addDefaults('Account', 'destroy').refresh === false).should.be.true;
+            (testConnector2.addDefaults('Account', 'destroyAll').refresh === false).should.be.true;
+            (testConnector2.addDefaults('Account', 'updateAttributes').refresh === true).should.be.true;
+            (testConnector2.addDefaults('Account', 'updateOrCreate').refresh === false).should.be.true;
+        });
+
+        it('create and destroy should have refresh false for model book', function () {
+            (testConnector2.addDefaults('Book', 'destroy').refresh === false).should.be.true;
+            (testConnector2.addDefaults('Book', 'create').refresh === false).should.be.true;
+            (testConnector2.addDefaults('Book', 'save').refresh === true).should.be.true;
+            (testConnector2.addDefaults('Book', 'destroyAll').refresh === 'wait_for').should.be.true;
+            (testConnector2.addDefaults('Book', 'updateAttributes').refresh === true).should.be.true;
+            (testConnector2.addDefaults('Book', 'updateOrCreate').refresh === false).should.be.true;
+        });
+
+    });
+
+    describe('Model specific settings', function () {
+
+        it('modifying operations should have refresh true', function () {
+            (testConnector.addDefaults('Account', 'create').refresh === true).should.be.true;
+            (testConnector.addDefaults('Account', 'save').refresh === true).should.be.true;
+            (testConnector.addDefaults('Account', 'destroy').refresh === true).should.be.true;
+            (testConnector.addDefaults('Account', 'destroyAll').refresh === true).should.be.true;
+            (testConnector.addDefaults('Account', 'updateAttributes').refresh === true).should.be.true;
+            (testConnector.addDefaults('Account', 'updateOrCreate').refresh === true).should.be.true;
+
+        });
+
+        it('create and destroy should have refresh false for model book', function () {
+            (testConnector.addDefaults('Book', 'destroy').refresh === false).should.be.true;
+            (testConnector.addDefaults('Book', 'create').refresh === false).should.be.true;
+            (testConnector.addDefaults('Book', 'save').refresh === true).should.be.true;
+            (testConnector.addDefaults('Book', 'destroyAll').refresh === 'wait_for').should.be.true;
+            (testConnector.addDefaults('Book', 'updateAttributes').refresh === true).should.be.true;
+            (testConnector.addDefaults('Book', 'updateOrCreate').refresh === true).should.be.true;
+        });
+
+    });
+});


### PR DESCRIPTION
- refresh: true be default for change operations
- configurable on datasource level (set it to true)
- configurable on per model and operation level (true, false, "wait_for")
- if not true, explicitly setting it to false (ES default)