### PR TITLE
Feature/refresh true hotfix

### DIFF
--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -348,9 +348,7 @@ ESConnector.prototype.addDefaults = function (modelName, functionName) {
     // When changing data, wait until the change has been indexed so it is instantly available for search
     if(this.refreshOn.indexOf(functionName) != -1) {
         filter.refresh = true;
-    } else {
-		filter.refresh = false;
-	}
+    }
 
     var modelClass = this._models[modelName];
     if (modelClass && _.isObject(modelClass.settings.elasticsearch) && _.isObject(modelClass.settings.elasticsearch.settings)) {

--- a/test/04.add-defaults-refresh-true.test.js
+++ b/test/04.add-defaults-refresh-true.test.js
@@ -63,6 +63,13 @@ describe('Add Defaults', function () {
             (typeof testConnector2.addDefaults('Book', 'updateOrCreate').refresh === 'undefined').should.be.true;
         });
 
+        it('should never have a refresh attribute', function () {
+            (typeof testConnector.addDefaults('Book', 'removeMappings').refresh === 'undefined').should.be.true;
+            (typeof testConnector.addDefaults('Book', 'buildFilter').refresh === 'undefined').should.be.true;
+            (typeof testConnector.addDefaults('Book', 'find').refresh === 'undefined').should.be.true;
+            (typeof testConnector.addDefaults('Book', 'exists').refresh === 'undefined').should.be.true;
+            (typeof testConnector.addDefaults('Book', 'count').refresh === 'undefined').should.be.true;
+        });
     });
 
     describe('Model specific settings', function () {

--- a/test/04.add-defaults-refresh-true.test.js
+++ b/test/04.add-defaults-refresh-true.test.js
@@ -46,12 +46,12 @@ describe('Add Defaults', function () {
     describe('Datasource specific settings', function () {
 
         it('modifying operations should have refresh true', function () {
-            (testConnector2.addDefaults('Account', 'create').refresh === false).should.be.true;
+            (typeof testConnector2.addDefaults('Account', 'create').refresh === 'undefined').should.be.true;
             (testConnector2.addDefaults('Account', 'save').refresh === true).should.be.true;
-            (testConnector2.addDefaults('Account', 'destroy').refresh === false).should.be.true;
-            (testConnector2.addDefaults('Account', 'destroyAll').refresh === false).should.be.true;
+            (typeof testConnector2.addDefaults('Account', 'destroy').refresh === 'undefined').should.be.true;
+            (typeof testConnector2.addDefaults('Account', 'destroyAll').refresh === 'undefined').should.be.true;
             (testConnector2.addDefaults('Account', 'updateAttributes').refresh === true).should.be.true;
-            (testConnector2.addDefaults('Account', 'updateOrCreate').refresh === false).should.be.true;
+            (typeof testConnector2.addDefaults('Account', 'updateOrCreate').refresh === 'undefined').should.be.true;
         });
 
         it('create and destroy should have refresh false for model book', function () {
@@ -60,7 +60,7 @@ describe('Add Defaults', function () {
             (testConnector2.addDefaults('Book', 'save').refresh === true).should.be.true;
             (testConnector2.addDefaults('Book', 'destroyAll').refresh === 'wait_for').should.be.true;
             (testConnector2.addDefaults('Book', 'updateAttributes').refresh === true).should.be.true;
-            (testConnector2.addDefaults('Book', 'updateOrCreate').refresh === false).should.be.true;
+            (typeof testConnector2.addDefaults('Book', 'updateOrCreate').refresh === 'undefined').should.be.true;
         });
 
     });


### PR DESCRIPTION
Sorry, maybe my last change was too fast.

Of course, certain operations should never have a refresh attribute.

And anyways, refresh: false is default, so no need for setting it.

Added tests just to make sure.