### PR TITLE
Param criteria in buildFilter should be of type Object

### DIFF
--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -369,7 +369,7 @@ ESConnector.prototype.addDefaults = function (modelName, functionName) {
  *   {"body": {"query": {"match": {"title": "Futuro"}}}}
  *   {"q" : "Futuro"}
  * @param {String} modelName filter
- * @param {String} criteria filter
+ * @param {Object} criteria filter
  * @param {number} size of rows to return, if null then skip
  * @param {number} offset to return, if null then skip
  * @returns {object} filter


### PR DESCRIPTION
#91 
I couldn't find any tests to check and validate argument types of functions. Also, chai doesn't support this feature. But I found this : https://github.com/theblacksmith/chai-param that does it.   May be of some use?