### PR TITLE
Fixed the query issue of `OR` inside an `AND` for `where` filter

### DIFF
--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -593,7 +593,7 @@ ESConnector.prototype.buildDeepNestedQueries = function (root, idName, where, bo
       else {
         var orObject = {bool: {should: []}};
         orPath = orObject.bool.should;
-        path.push(orPath);
+        path.push(orObject);
       }
       cond.map(function (c) {
         log('ESConnector.prototype.buildDeepNestedQueries', 'mapped', 'body', JSON.stringify(body, null, 0));
@@ -704,9 +704,9 @@ ESConnector.prototype.buildDeepNestedQueries = function (root, idName, where, bo
           // body.query.bool.must.push(missingFilter);
         }
         // TODO: near - For geolocations, return the closest points, sorted in order of distance.  Use with limit to return the n closest points.
-                // TODO: like, nlike
-                // TODO: ilike, inlike
-                // TODO: regex
+        // TODO: like, nlike
+        // TODO: ilike, inlike
+        // TODO: regex
       }
       else {
         var nestedQuery = {match: {}};

--- a/test/es-v1/01.filters.test.js
+++ b/test/es-v1/01.filters.test.js
@@ -310,6 +310,75 @@ describe('Connector', function () {
 		done();
 	});
 
+	it('should build a nested "and" and "or" query for the WHERE filter', function (done) {
+		var criteria, size, offset, modelName, modelIdName;
+		criteria = {
+			where: {
+				and: [
+					{ or: [{id: {inq:[3,4,5] }}, { vip: true }] },
+					{ role: 'lead' }
+				]
+			}
+		};
+		size = 100;
+		offset = 10;
+		modelName = 'MockLoopbackModel';
+		modelIdName = 'id';
+
+		var filterCriteria = testConnector.buildFilter(modelName, modelIdName, criteria, size, offset);
+		expect(filterCriteria).not.to.be.null;
+		expect(filterCriteria).to.have.property('index').that.is.a('string');
+		expect(filterCriteria).to.have.property('type').that.is.a('string').that.equals(modelName);
+		expect(filterCriteria).to.have.property('body')
+			.that.is.an('object')
+			.that.deep.equals({ // a. this is really 2 tests in one
+			sort: [
+				// b. `_uid` is an auto-generated field that ElasticSearch populates for us
+				// when we want to let the backend/system/ES take care of id population
+				// so if we want to sort by id, without specifying/controlling our own id field,
+				// then ofcourse the sort must happen on `_uid`, this part of the test, validates that!
+				'_uid'
+			],
+			query: {
+				bool: {
+					must: [
+						{
+							bool: {
+								should: [
+									{
+										terms: {
+											_id: [
+												3,
+												4,
+												5
+											]
+										}
+									},
+									{
+										match: {
+											vip: true
+										}
+									}
+								]
+							}
+						},
+						{
+							match: {
+								role: 'lead'
+							}
+						}
+					]
+				}
+			}
+		});
+		expect(filterCriteria).to.have.property('size')
+			.that.is.a('number');
+		expect(filterCriteria).to.have.property('from')
+			.that.is.a('number');
+
+		done();
+	});
+
 	it('should build a "nin" query for the WHERE filter', function (done) {
 		var criteria, size, offset, modelName, modelIdName;
 		criteria = {

--- a/test/es-v2/01.filters.test.js
+++ b/test/es-v2/01.filters.test.js
@@ -310,6 +310,75 @@ describe('Connector', function () {
 		done();
 	});
 
+	it('should build a nested "and" and "or" query for the WHERE filter', function (done) {
+		var criteria, size, offset, modelName, modelIdName;
+		criteria = {
+			where: {
+				and: [
+					{ or: [{id: {inq:[3,4,5] }}, { vip: true }] },
+					{ role: 'lead' }
+				]
+			}
+		};
+		size = 100;
+		offset = 10;
+		modelName = 'MockLoopbackModel';
+		modelIdName = 'id';
+
+		var filterCriteria = testConnector.buildFilter(modelName, modelIdName, criteria, size, offset);
+		expect(filterCriteria).not.to.be.null;
+		expect(filterCriteria).to.have.property('index').that.is.a('string');
+		expect(filterCriteria).to.have.property('type').that.is.a('string').that.equals(modelName);
+		expect(filterCriteria).to.have.property('body')
+			.that.is.an('object')
+			.that.deep.equals({ // a. this is really 2 tests in one
+			sort: [
+				// b. `_uid` is an auto-generated field that ElasticSearch populates for us
+				// when we want to let the backend/system/ES take care of id population
+				// so if we want to sort by id, without specifying/controlling our own id field,
+				// then ofcourse the sort must happen on `_uid`, this part of the test, validates that!
+				'_uid'
+			],
+			query: {
+				bool: {
+					must: [
+						{
+							bool: {
+								should: [
+									{
+										terms: {
+											_id: [
+												3,
+												4,
+												5
+											]
+										}
+									},
+									{
+										match: {
+											vip: true
+										}
+									}
+								]
+							}
+						},
+						{
+							match: {
+								role: 'lead'
+							}
+						}
+					]
+				}
+			}
+		});
+		expect(filterCriteria).to.have.property('size')
+			.that.is.a('number');
+		expect(filterCriteria).to.have.property('from')
+			.that.is.a('number');
+
+		done();
+	});
+
 	it('should build a "nin" query for the WHERE filter', function (done) {
 		var criteria, size, offset, modelName, modelIdName;
 		criteria = {

--- a/test/es-v5/01.filters.test.js
+++ b/test/es-v5/01.filters.test.js
@@ -310,6 +310,75 @@ describe('Connector', function () {
 		done();
 	});
 
+	it('should build a nested "and" and "or" query for the WHERE filter', function (done) {
+		var criteria, size, offset, modelName, modelIdName;
+		criteria = {
+			where: {
+				and: [
+					{ or: [{id: {inq:[3,4,5] }}, { vip: true }] },
+					{ role: 'lead' }
+				]
+			}
+		};
+		size = 100;
+		offset = 10;
+		modelName = 'MockLoopbackModel';
+		modelIdName = 'id';
+
+		var filterCriteria = testConnector.buildFilter(modelName, modelIdName, criteria, size, offset);
+		expect(filterCriteria).not.to.be.null;
+		expect(filterCriteria).to.have.property('index').that.is.a('string');
+		expect(filterCriteria).to.have.property('type').that.is.a('string').that.equals(modelName);
+		expect(filterCriteria).to.have.property('body')
+			.that.is.an('object')
+			.that.deep.equals({ // a. this is really 2 tests in one
+			sort: [
+				// b. `_uid` is an auto-generated field that ElasticSearch populates for us
+				// when we want to let the backend/system/ES take care of id population
+				// so if we want to sort by id, without specifying/controlling our own id field,
+				// then ofcourse the sort must happen on `_uid`, this part of the test, validates that!
+				'_uid'
+			],
+			query: {
+				bool: {
+					must: [
+						{
+							bool: {
+								should: [
+									{
+										terms: {
+											_id: [
+												3,
+												4,
+												5
+											]
+										}
+									},
+									{
+										match: {
+											vip: true
+										}
+									}
+								]
+							}
+						},
+						{
+							match: {
+								role: 'lead'
+							}
+						}
+					]
+				}
+			}
+		});
+		expect(filterCriteria).to.have.property('size')
+			.that.is.a('number');
+		expect(filterCriteria).to.have.property('from')
+			.that.is.a('number');
+
+		done();
+	});
+
 	it('should build a "nin" query for the WHERE filter', function (done) {
 		var criteria, size, offset, modelName, modelIdName;
 		criteria = {


### PR DESCRIPTION
Many thanks to @AhsanAyaz for https://github.com/strongloop-community/loopback-connector-elastic-search/pull/99