### PR TITLE
Specify the version of http-aws-es needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ npm install loopback-connector-es --save --save-exact
 - **ssl:** useful for setting up a secure channel
 - **protocol:** can be `http` or `https` (`http` is the default if none specified) ... *must* be `https` if you're using `ssl`
 - **auth**: useful if you have access control setup via services like `es-jetty` or `found` or `shield`
-- **amazonES**: configuration for `http-aws-es` NOTE: The package needs to be installed in your project. Its not part of this Connector.
+- **amazonES**: configuration for `http-aws-es` NOTE: The package needs to be installed in your project. Its not part of this Connector. Version 1.x.x (currently 1.1.3) will have to be used, later versions will not pass through aws configuration.
 
 ### Sample:
 1. Edit **datasources.json** and set:


### PR DESCRIPTION
`http-aws-es` has had quite a few updates now and it does not support passing through credentials in the same manner. This could be remedied by simply creating a AWS.Config object to pass in as a parameter instead of the credentials however just updating the readme should also make it functional.