### PR TITLE
Fixed include and limit filter issues for ElasticSearch 6

### DIFF
--- a/lib/esConnector.js
+++ b/lib/esConnector.js
@@ -419,6 +419,18 @@ ESConnector.prototype.buildFilter = function(modelName, idName, criteria, size, 
        but the test which should fail until I implement such a feature ... is actually passing!
        ... did someone at some point of time implement an in-memory filter for FIELDS
        in the underlying loopback-connector implementation? */
+
+       // Elasticsearch _source filtering code
+       /*if (Array.isArray(criteria.fields) || typeof criteria.fields === "string") {
+        filter.body._source = criteria.fields;
+      } else if (typeof criteria.fields === "object" && Object.keys(criteria.fields).length > 0) {
+        filter.body._source.includes = _.map(_.pickBy(criteria.fields, function(v, k) {
+          return v === true;
+        }), function(v, k) { return k; });
+        filter.body._source.excludes = _.map(_.pickBy(criteria.fields, function(v, k) {
+          return v === false;
+        }), function(v, k) { return k; });
+      }*/
     }
     if (criteria.order) {
       log('ESConnector.prototype.buildFilter', 'will delegate sorting to buildOrder()');
@@ -437,9 +449,7 @@ ESConnector.prototype.buildFilter = function(modelName, idName, criteria, size, 
     }
     if (criteria.where) {
       filter.body.query = self.buildWhere(modelName, idName, criteria.where).query;
-    }
-    // TODO: Include filter
-    else if (criteria.suggests) { // TODO: remove HACK!!!
+    } else if (criteria.suggests) { // TODO: remove HACK!!!
       if (self.settings.apiVersion.indexOf('5') === 0) {
         filter.body = {
           suggest: criteria.suggests
@@ -468,6 +478,10 @@ ESConnector.prototype.buildFilter = function(modelName, idName, criteria, size, 
           }
         }
       };
+    } 
+    // For 'limit' and 'include filters'
+    else if (criteria.limit || criteria.include) {
+      filter.body.query = self.buildWhere(modelName, idName, criteria.where || {}).query;
     }
   }
 

--- a/lib/setupMapping.js
+++ b/lib/setupMapping.js
@@ -50,19 +50,19 @@ var setupMapping = function(mappingType) {
   log('ESConnector.prototype.setupMapping', 'will setup mapping for mappingType:', mappingFromDatasource.name);
 
   //return self.setupIndices(defaults.index)
-  // return self.setupIndex(defaults.index)
-  // .then(function() {
-  log('ESConnector.prototype.setupMapping', 'db.indices.putMapping', 'mappingType:', mappingType, 'start');
-  return db.indices.putMapping(_.defaults({ body: mapping }, defaults))
-    .then(function(body) {
-      log('ESConnector.prototype.setupMapping', 'db.indices.putMapping', 'mappingType:', mappingType, 'response', body);
-      return Promise.resolve();
-    }, function(err) {
-      log('ESConnector.prototype.setupMapping', 'db.indices.putMapping', 'mappingType:', mappingType, 'failed', err);
-      //console.trace(err.message);
-      return Promise.reject(err);
+  return self.setupIndex(defaults.index)
+    .then(function() {
+      log('ESConnector.prototype.setupMapping', 'db.indices.putMapping', 'mappingType:', mappingType, 'start');
+      return db.indices.putMapping(_.defaults({ body: mapping }, defaults))
+        .then(function(body) {
+          log('ESConnector.prototype.setupMapping', 'db.indices.putMapping', 'mappingType:', mappingType, 'response', body);
+          return Promise.resolve();
+        }, function(err) {
+          log('ESConnector.prototype.setupMapping', 'db.indices.putMapping', 'mappingType:', mappingType, 'failed', err);
+          //console.trace(err.message);
+          return Promise.reject(err);
+        });
     });
-  // });
 };
 
 module.exports = function(dependencies) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-esv6",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "LoopBack Connector for Elasticsearch 6.x",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-esv6",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "LoopBack Connector for Elasticsearch 6.x",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* "limit" and "include" filter gives documents not related to model when used without 'where' filter. This issue is fixed by providing empty object {} for where filter.